### PR TITLE
Better request skeleton

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/minijson_writer"]
+	path = vendor/minijson_writer
+	url = https://github.com/giacomodrago/minijson_writer.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ add_executable(flora
         ui/ProtocolTreeModel.cpp
         ui/ProtocolTreeModel.h
         util/GrpcUtility.cpp
-        util/GrpcUtility.h)
+        util/GrpcUtility.h util/ProtobufIterator.h)
 
 target_link_libraries(flora
         Qt5::Widgets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,10 +32,15 @@ add_executable(flora
         ui/ProtocolTreeModel.cpp
         ui/ProtocolTreeModel.h
         util/GrpcUtility.cpp
-        util/GrpcUtility.h util/ProtobufIterator.h)
+        util/GrpcUtility.h
+        util/ProtobufIterator.h
+        util/ProtobufJsonPrinter.cpp
+        util/ProtobufJsonPrinter.h)
 
 target_link_libraries(flora
         Qt5::Widgets
         KF5::SyntaxHighlighting
         protobuf::libprotobuf
         grpc++)
+
+target_include_directories(flora PRIVATE ${PROJECT_SOURCE_DIR}/vendor/minijson_writer)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 FloraRPC
+====
 
 QtでgRPC Clientを書いてみる試み。Awesome gRPCを見てもネイティブのデスクトップGUIツールキットを使った実装が全然無かったので……。
 
@@ -8,6 +9,11 @@ QtでgRPC Clientを書いてみる試み。Awesome gRPCを見てもネイティ�
 - gRPC 1.27
 - KSyntaxHighlighting 5.67
 
+## Build (for Arch Linux)
+
 ```sh
 $ yay -S cmake qt5-base protobuf grpc syntax-highlighting
+$ git submodule update --init
+$ cmake .
+$ make
 ```

--- a/entity/Method.cpp
+++ b/entity/Method.cpp
@@ -1,5 +1,6 @@
 #include "Method.h"
 #include "../util/GrpcUtility.h"
+#include "../util/ProtobufJsonPrinter.h"
 #include <sstream>
 #include <google/protobuf/dynamic_message.h>
 #include <google/protobuf/util/json_util.h>
@@ -17,15 +18,7 @@ std::string Method::getRequestPath() {
 }
 
 std::string Method::makeRequestSkeleton() {
-    google::protobuf::DynamicMessageFactory dmf;
-    auto proto = dmf.GetPrototype(descriptor->input_type());
-    auto message = std::unique_ptr<google::protobuf::Message>(proto->New());
-    google::protobuf::util::JsonOptions opts;
-    opts.add_whitespace = true;
-    opts.always_print_primitive_fields = true;
-    std::string out;
-    google::protobuf::util::MessageToJsonString(*message, &out, opts);
-    return out;
+    return ProtobufJsonPrinter::makeRequestSkeleton(descriptor->input_type());
 }
 
 std::unique_ptr<google::protobuf::Message>

--- a/util/ProtobufIterator.h
+++ b/util/ProtobufIterator.h
@@ -1,0 +1,65 @@
+#ifndef FLORARPC_PROTOBUFITERATOR_H
+#define FLORARPC_PROTOBUFITERATOR_H
+
+#include <google/protobuf/descriptor.h>
+
+namespace ProtobufIterator {
+    using namespace google::protobuf;
+
+    template <class T>
+    struct Adapter {};
+
+    template <>
+    struct Adapter<FieldDescriptor> {
+        static inline const FieldDescriptor* lookup(const Descriptor *d, int i) {
+            return d->field(i);
+        }
+        static inline int count(const Descriptor *d) {
+            return d->field_count();
+        }
+    };
+
+    template <class T>
+    class Iterator {
+    public:
+        Iterator(const Descriptor *d, int index) : d(d), index(index) {}
+        const T* operator*() {
+            return Adapter<T>::lookup(d, index);
+        }
+        const T* operator->() {
+            return Adapter<T>::lookup(d, index);
+        }
+        Iterator<T>& operator++() {
+            index++;
+            return *this;
+        }
+        Iterator<T> operator++(int) {
+            Iterator<T> res = *this;
+            index++;
+            return res;
+        }
+        bool operator!=(const Iterator<T>& iter) {
+            return this->d != iter.d || this->index != iter.index;
+        }
+
+    private:
+        const Descriptor *d;
+        int index;
+    };
+
+    template <class T>
+    class Iterable {
+    public:
+        Iterable(const Descriptor *d) : d(d) {}
+        Iterator<T> begin() {
+            return Iterator<T>(d, 0);
+        }
+        Iterator<T> end() {
+            return Iterator<T>(d, Adapter<T>::count(d));
+        }
+    private:
+        const Descriptor *d;
+    };
+}
+
+#endif //FLORARPC_PROTOBUFITERATOR_H

--- a/util/ProtobufJsonPrinter.cpp
+++ b/util/ProtobufJsonPrinter.cpp
@@ -1,0 +1,86 @@
+#include <google/protobuf/descriptor.h>
+#include <minijson_writer.hpp>
+#include "ProtobufIterator.h"
+#include "ProtobufJsonPrinter.h"
+
+template <typename T>
+static void write2json(minijson::object_writer &writer, const std::string &name, bool repeated, const T &value) {
+    if (repeated) {
+        auto array = writer.nested_array(name.c_str());
+        array.write(value);
+        array.close();
+    } else {
+        writer.write(name.c_str(), value);
+    }
+}
+
+static void desc2json(minijson::object_writer &writer, const google::protobuf::Descriptor *descriptor) {
+    ProtobufIterator::Iterable<google::protobuf::FieldDescriptor> rootFields(descriptor);
+    for (auto field : rootFields) {
+        // TODO: better map support
+        switch (field->type()) {
+            case google::protobuf::FieldDescriptor::TYPE_DOUBLE:
+                write2json(writer, field->camelcase_name(), field->is_repeated(), field->default_value_double());
+                break;
+            case google::protobuf::FieldDescriptor::TYPE_FLOAT:
+                write2json(writer, field->camelcase_name(), field->is_repeated(), field->default_value_float());
+                break;
+            case google::protobuf::FieldDescriptor::TYPE_INT64:
+            case google::protobuf::FieldDescriptor::TYPE_FIXED64:
+            case google::protobuf::FieldDescriptor::TYPE_SINT64:
+            case google::protobuf::FieldDescriptor::TYPE_SFIXED64:
+                write2json(writer, field->camelcase_name(), field->is_repeated(), field->default_value_int64());
+                break;
+            case google::protobuf::FieldDescriptor::TYPE_UINT64:
+                write2json(writer, field->camelcase_name(), field->is_repeated(), field->default_value_uint64());
+                break;
+            case google::protobuf::FieldDescriptor::TYPE_INT32:
+            case google::protobuf::FieldDescriptor::TYPE_FIXED32:
+            case google::protobuf::FieldDescriptor::TYPE_SFIXED32:
+            case google::protobuf::FieldDescriptor::TYPE_SINT32:
+                write2json(writer, field->camelcase_name(), field->is_repeated(), field->default_value_int32());
+                break;
+            case google::protobuf::FieldDescriptor::TYPE_UINT32:
+                write2json(writer, field->camelcase_name(), field->is_repeated(), field->default_value_uint32());
+                break;
+            case google::protobuf::FieldDescriptor::TYPE_BOOL:
+                write2json(writer, field->camelcase_name(), field->is_repeated(), field->default_value_bool());
+                break;
+            case google::protobuf::FieldDescriptor::TYPE_STRING:
+                write2json(writer, field->camelcase_name(), field->is_repeated(), field->default_value_string());
+                break;
+            case google::protobuf::FieldDescriptor::TYPE_GROUP:
+                break;
+            case google::protobuf::FieldDescriptor::TYPE_MESSAGE: {
+                // TODO: better well-known type supports (e.g. google.protobuf.Timestamp)
+                if (field->is_repeated()) {
+                    auto array = writer.nested_array(field->camelcase_name().c_str());
+                    auto message = array.nested_object();
+                    desc2json(message, field->message_type());
+                    message.close();
+                    array.close();
+                } else {
+                    auto message = writer.nested_object(field->camelcase_name().c_str());
+                    desc2json(message, field->message_type());
+                    message.close();
+                }
+                break;
+            }
+            case google::protobuf::FieldDescriptor::TYPE_BYTES:
+                writer.write(field->camelcase_name().c_str(), "");
+                break;
+            case google::protobuf::FieldDescriptor::TYPE_ENUM:
+                writer.write(field->camelcase_name().c_str(), field->default_value_enum()->name());
+                break;
+        }
+    }
+}
+
+std::string ProtobufJsonPrinter::makeRequestSkeleton(const google::protobuf::Descriptor *descriptor) {
+    std::stringstream stream;
+    minijson::object_writer writer(stream,
+                                   minijson::writer_configuration().pretty_printing(true).indent_spaces(2));
+    desc2json(writer, descriptor);
+    writer.close();
+    return std::string(stream.str());
+}

--- a/util/ProtobufJsonPrinter.h
+++ b/util/ProtobufJsonPrinter.h
@@ -1,0 +1,11 @@
+#ifndef FLORARPC_PROTOBUFJSONPRINTER_H
+#define FLORARPC_PROTOBUFJSONPRINTER_H
+
+#include <string>
+#include <google/protobuf/descriptor.h>
+
+namespace ProtobufJsonPrinter {
+    std::string makeRequestSkeleton(const google::protobuf::Descriptor *descriptor);
+}
+
+#endif //FLORARPC_PROTOBUFJSONPRINTER_H


### PR DESCRIPTION
fix #12 

入れ子になったMessageがあってもちゃんとリクエストスケルトンが吐かれるように、自前でJSONを書き出すようにした。  
この作業にあたって、ライブラリも追加。

proto2 Groupへの対応が省かれているのと、Mapの対応が上手くできていない。