### PR TITLE
Catalinaの中華フォント対策

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -9,11 +9,17 @@
 #include <QLocale>
 #endif
 
+#ifdef __APPLE__
+#include <QOperatingSystemVersion>
+#include <QFont>
+#include <QLocale>
+#endif
+
 int main(int argc, char *argv[]) {
     QApplication app(argc, argv);
 
 #ifdef _WIN32
-    // ���{��Windows���g���l���~�ς���
+    // 日本語Windowsを使う人を救済する
     QLocale locale;
     if (locale.language() == QLocale::Language::Japanese) {
         QFont fontYuGothic("Yu Gothic UI", 9);
@@ -23,6 +29,19 @@ int main(int argc, char *argv[]) {
             QFont fontMeiryo("Meiryo UI", 9);
             app.setFont(fontMeiryo);
         }
+    }
+#endif
+
+#ifdef __APPLE__
+    // Catalinaでは、漢字が常に中華フォントで描画されてしまう問題がある。
+    // -> https://bugreports.qt.io/browse/QTBUG-81924
+    // そこで、とりあえずHiragino Sansにフォールバックするようにする。
+    // -> https://bugreports.qt.io/browse/QTBUG-81924?focusedCommentId=497035&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-497035
+    // TODO: UIテキストをi18nするまでは、ロケールに関係なくフォールバックを書き込んだほうがいいかもしれない。
+    QLocale locale;
+    if (locale.language() == QLocale::Language::Japanese &&
+        QOperatingSystemVersion::current() >= QOperatingSystemVersion::MacOSCatalina) {
+        QFont::insertSubstitution(".AppleSystemUIFont", "Hiragino Sans");
     }
 #endif
 


### PR DESCRIPTION
refs #23 

macOS Catalinaで中華フォントが使われてしまう問題への対策。現状では、UIには英語および日本語のみを使用しているので大陸のフォントになるのは不適切。

日本語ロケール環境では、フォールバックとしてHiragino Sansを登録するようにした。  
ただし、日本人のmacOSユーザはしばしば英語ロケールでシステムを運用しているので、UIのi18nに着手するまではロケールに関わらず一律で対応しても良いかもしれない。

## Before
<img width="523" alt="スクリーンショット 2020-04-04 13 10 26" src="https://user-images.githubusercontent.com/1352154/78418332-2bb93d00-7676-11ea-8b62-ce2e24522eb3.png">

## After
<img width="532" alt="スクリーンショット 2020-04-04 13 10 57" src="https://user-images.githubusercontent.com/1352154/78418334-3247b480-7676-11ea-968b-36b4c20dabef.png">

## 参考
* https://bugreports.qt.io/browse/QTBUG-81924
* https://bugreports.qt.io/browse/QTBUG-81924?focusedCommentId=497035&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-497035