### PR TITLE
接続先管理

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,6 @@ indent_size = 2
 
 [*.yml]
 indent_size = 2
+
+[*.ui]
+indent_size = 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,13 +103,19 @@ add_executable(flora
         ui/MultiPageJsonView.cpp
         ui/MultiPageJsonView.h
         ui/ServerEditDialog.ui
+        ui/ServerEditDialog.cpp
+        ui/ServerEditDialog.h
         ui/ServersManageDialog.ui
+        ui/ServersManageDialog.cpp
+        ui/ServersManageDialog.h
         entity/Protocol.cpp
         entity/Protocol.h
         entity/Method.cpp
         entity/Method.h
         entity/Session.cpp
         entity/Session.h
+        entity/Server.cpp
+        entity/Server.h
         ui/ProtocolTreeModel.cpp
         ui/ProtocolTreeModel.h
         util/GrpcUtility.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,8 @@ add_executable(flora
         ui/MultiPageJsonView.ui
         ui/MultiPageJsonView.cpp
         ui/MultiPageJsonView.h
+        ui/ServerEditDialog.ui
+        ui/ServersManageDialog.ui
         entity/Protocol.cpp
         entity/Protocol.h
         entity/Method.cpp

--- a/entity/Server.cpp
+++ b/entity/Server.cpp
@@ -1,0 +1,1 @@
+#include "Server.h"

--- a/entity/Server.cpp
+++ b/entity/Server.cpp
@@ -1,1 +1,5 @@
 #include "Server.h"
+
+Server::Server() : Server(QUuid::createUuid()) {}
+
+Server::Server(QUuid id) : id(id) {}

--- a/entity/Server.cpp
+++ b/entity/Server.cpp
@@ -11,7 +11,7 @@ Server::Server(const florarpc::Server& server)
       useTLS(server.usetls()) {}
 
 void Server::writeServer(florarpc::Server& server) {
-    server.set_id(id.toByteArray().toStdString());
+    server.set_id(id.toString().toStdString());
     server.set_name(name.toStdString());
     server.set_address(address.toStdString());
     server.set_usetls(useTLS);

--- a/entity/Server.cpp
+++ b/entity/Server.cpp
@@ -3,3 +3,16 @@
 Server::Server() : Server(QUuid::createUuid()) {}
 
 Server::Server(QUuid id) : id(id) {}
+
+Server::Server(const florarpc::Server& server)
+    : id(QByteArray::fromStdString(server.id())),
+      name(QString::fromStdString(server.name())),
+      address(QString::fromStdString(server.address())),
+      useTLS(server.usetls()) {}
+
+void Server::writeServer(florarpc::Server& server) {
+    server.set_id(id.toByteArray().toStdString());
+    server.set_name(name.toStdString());
+    server.set_address(address.toStdString());
+    server.set_usetls(useTLS);
+}

--- a/entity/Server.h
+++ b/entity/Server.h
@@ -1,0 +1,13 @@
+#ifndef FLORARPC_SERVER_H
+#define FLORARPC_SERVER_H
+
+#include <QString>
+
+class Server {
+public:
+    QString name;
+    QString address;
+    bool useTLS;
+};
+
+#endif  // FLORARPC_SERVER_H

--- a/entity/Server.h
+++ b/entity/Server.h
@@ -2,9 +2,14 @@
 #define FLORARPC_SERVER_H
 
 #include <QString>
+#include <QUuid>
 
 class Server {
 public:
+    Server();
+    explicit Server(QUuid id);
+
+    QUuid id;
     QString name;
     QString address;
     bool useTLS;

--- a/entity/Server.h
+++ b/entity/Server.h
@@ -4,10 +4,15 @@
 #include <QString>
 #include <QUuid>
 
+#include "florarpc/workspace.pb.h"
+
 class Server {
 public:
     Server();
     explicit Server(QUuid id);
+    explicit Server(const florarpc::Server &server);
+
+    void writeServer(florarpc::Server &server);
 
     QUuid id;
     QString name;

--- a/proto/florarpc/uuid.proto
+++ b/proto/florarpc/uuid.proto
@@ -1,7 +1,0 @@
-syntax = "proto3";
-
-package florarpc;
-
-message UUID {
-  bytes uuid = 1;
-}

--- a/proto/florarpc/workspace.proto
+++ b/proto/florarpc/workspace.proto
@@ -30,11 +30,11 @@ message Request {
   MethodRef method = 1;
   string body_draft = 2;
   string metadata_draft = 3;
-  bytes selected_server_id = 4;
+  string selected_server_id = 4;
 }
 
 message Server {
-  bytes id = 1;
+  string id = 1;
   string name = 2;
   string address = 3;
   bool useTLS = 4;

--- a/proto/florarpc/workspace.proto
+++ b/proto/florarpc/workspace.proto
@@ -30,3 +30,10 @@ message Request {
   string body_draft = 2;
   string metadata_draft = 3;
 }
+
+message Server {
+  bytes id = 1;
+  string name = 2;
+  string address = 3;
+  bool useTLS = 4;
+}

--- a/proto/florarpc/workspace.proto
+++ b/proto/florarpc/workspace.proto
@@ -9,6 +9,7 @@ message Workspace {
   repeated ProtoFile proto_files = 2;
   repeated ImportPath import_paths = 3;
   repeated Request requests = 4;
+  repeated Server servers = 5;
 }
 
 message ProtoFile {
@@ -29,6 +30,7 @@ message Request {
   MethodRef method = 1;
   string body_draft = 2;
   string metadata_draft = 3;
+  bytes selected_server_id = 4;
 }
 
 message Server {

--- a/ui/Editor.cpp
+++ b/ui/Editor.cpp
@@ -118,7 +118,7 @@ void Editor::readRequest(const florarpc::Request &request) {
     ui.requestEdit->setPlainText(QString::fromStdString(request.body_draft()));
     ui.requestMetadataEdit->setPlainText(QString::fromStdString(request.metadata_draft()));
     for (std::vector<std::shared_ptr<Server>>::size_type i = 0; i < servers.size(); i++) {
-        if (request.selected_server_id() == servers[i]->id.toByteArray().toStdString()) {
+        if (request.selected_server_id() == servers[i]->id.toString().toStdString()) {
             ui.serverSelectBox->setCurrentIndex(i);
             break;
         }

--- a/ui/Editor.cpp
+++ b/ui/Editor.cpp
@@ -91,9 +91,9 @@ Editor::Editor(std::unique_ptr<Method> &&method,
 }
 
 void Editor::setServers(std::vector<std::shared_ptr<Server>> servers) {
-    QString selected = nullptr;
+    QUuid selected = nullptr;
     if (!this->servers.empty()) {
-        selected = this->servers[ui.serverSelectBox->currentIndex()]->address;
+        selected = this->servers[ui.serverSelectBox->currentIndex()]->id;
     }
 
     this->servers = servers;
@@ -107,7 +107,7 @@ void Editor::setServers(std::vector<std::shared_ptr<Server>> servers) {
         ui.executeButton->setDisabled(false);
         for (std::vector<std::shared_ptr<Server>>::size_type i = 0; i < servers.size(); i++) {
             ui.serverSelectBox->addItem(servers[i]->name);
-            if (selected == servers[i]->address) {
+            if (selected == servers[i]->id) {
                 ui.serverSelectBox->setCurrentIndex(i);
             }
         }

--- a/ui/Editor.cpp
+++ b/ui/Editor.cpp
@@ -117,6 +117,12 @@ void Editor::setServers(std::vector<std::shared_ptr<Server>> servers) {
 void Editor::readRequest(const florarpc::Request &request) {
     ui.requestEdit->setPlainText(QString::fromStdString(request.body_draft()));
     ui.requestMetadataEdit->setPlainText(QString::fromStdString(request.metadata_draft()));
+    for (std::vector<std::shared_ptr<Server>>::size_type i = 0; i < servers.size(); i++) {
+        if (request.selected_server_id() == servers[i]->id.toByteArray().toStdString()) {
+            ui.serverSelectBox->setCurrentIndex(i);
+            break;
+        }
+    }
 }
 
 void Editor::writeRequest(florarpc::Request &request) {
@@ -125,6 +131,7 @@ void Editor::writeRequest(florarpc::Request &request) {
 
     request.set_body_draft(ui.requestEdit->toPlainText().toStdString());
     request.set_metadata_draft(ui.requestMetadataEdit->toPlainText().toStdString());
+    request.set_selected_server_id(getCurrentServer()->id.toByteArray().toStdString());
 }
 
 void Editor::onExecuteButtonClicked() {

--- a/ui/Editor.cpp
+++ b/ui/Editor.cpp
@@ -22,7 +22,6 @@ Editor::Editor(std::unique_ptr<Method> &&method,
         : QWidget(parent), responseMetadataContextMenu(new QMenu(this)), session(nullptr), method(std::move(method)) {
     ui.setupUi(this);
 
-    connect(ui.serverAddressEdit, &QLineEdit::textChanged, this, &Editor::onServerAddressEditTextChanged);
     connect(ui.executeButton, &QPushButton::clicked, this, &Editor::onExecuteButtonClicked);
     connect(ui.sendButton, &QPushButton::clicked, this, &Editor::onSendButtonClicked);
     connect(ui.finishButton, &QPushButton::clicked, this, &Editor::onFinishButtonClicked);
@@ -91,6 +90,30 @@ Editor::Editor(std::unique_ptr<Method> &&method,
     hideStreamingButtons();
 }
 
+void Editor::setServers(std::vector<std::shared_ptr<Server>> servers) {
+    QString selected = nullptr;
+    if (!this->servers.empty()) {
+        selected = this->servers[ui.serverSelectBox->currentIndex()]->address;
+    }
+
+    this->servers = servers;
+    ui.serverSelectBox->clear();
+    if (servers.empty()) {
+        ui.serverSelectBox->setDisabled(true);
+        ui.serverSelectBox->addItem("ファイル→接続先の管理 から追加してください");
+        ui.executeButton->setDisabled(true);
+    } else {
+        ui.serverSelectBox->setDisabled(false);
+        ui.executeButton->setDisabled(false);
+        for (std::vector<std::shared_ptr<Server>>::size_type i = 0; i < servers.size(); i++) {
+            ui.serverSelectBox->addItem(servers[i]->name);
+            if (selected == servers[i]->address) {
+                ui.serverSelectBox->setCurrentIndex(i);
+            }
+        }
+    }
+}
+
 void Editor::readRequest(const florarpc::Request &request) {
     ui.requestEdit->setPlainText(QString::fromStdString(request.body_draft()));
     ui.requestMetadataEdit->setPlainText(QString::fromStdString(request.metadata_draft()));
@@ -102,9 +125,6 @@ void Editor::writeRequest(florarpc::Request &request) {
 
     request.set_body_draft(ui.requestEdit->toPlainText().toStdString());
     request.set_metadata_draft(ui.requestMetadataEdit->toPlainText().toStdString());
-}
-
-void Editor::onServerAddressEditTextChanged(const QString &text) { ui.executeButton->setEnabled(!text.isEmpty());
 }
 
 void Editor::onExecuteButtonClicked() {
@@ -162,8 +182,9 @@ void Editor::onExecuteButtonClicked() {
         }
     }
 
-    auto credentials = getDefaultCredentials(ui.useTlsCheck->isChecked());
-    session = new Session(*method, ui.serverAddressEdit->text(), credentials, metadata, this);
+    auto server = getCurrentServer();
+    auto credentials = getDefaultCredentials(server->useTLS);
+    session = new Session(*method, server->address, credentials, metadata, this);
     connect(session, &Session::messageSent, this, &Editor::onMessageSent);
     connect(session, &Session::messageReceived, this, &Editor::onMessageReceived);
     connect(session, &Session::initialMetadataReceived, this, &Editor::onMetadataReceived);
@@ -388,4 +409,12 @@ void Editor::updateResponsePager() {
     if (ui.responseBodyPageSpin->value() == responses.size()) {
         ui.nextResponseBodyButton->setDisabled(true);
     }
+}
+
+std::shared_ptr<Server> Editor::getCurrentServer() {
+    if (servers.empty()) {
+        return nullptr;
+    }
+
+    return servers[ui.serverSelectBox->currentIndex()];
 }

--- a/ui/Editor.h
+++ b/ui/Editor.h
@@ -9,6 +9,7 @@
 #include <QWidget>
 
 #include "../entity/Method.h"
+#include "../entity/Server.h"
 #include "../entity/Session.h"
 #include "florarpc/workspace.pb.h"
 #include "ui/ui_Editor.h"
@@ -21,13 +22,13 @@ public:
 
     inline Method &getMethod() { return *method; }
 
+    void setServers(std::vector<std::shared_ptr<Server>> servers);
+
     void readRequest(const florarpc::Request &request);
 
     void writeRequest(florarpc::Request &request);
 
 private slots:
-
-    void onServerAddressEditTextChanged(const QString &text);
 
     void onExecuteButtonClicked();
 
@@ -60,6 +61,7 @@ private:
     QVector<grpc::ByteBuffer> responses;
 
     std::unique_ptr<Method> method;
+    std::vector<std::shared_ptr<Server>> servers;
 
     std::unique_ptr<KSyntaxHighlighting::SyntaxHighlighter> requestHighlighter;
     std::unique_ptr<KSyntaxHighlighting::SyntaxHighlighter> requestMetadataHighlighter;
@@ -79,6 +81,8 @@ private:
     void hideStreamingButtons();
 
     void updateResponsePager();
+
+    std::shared_ptr<Server> getCurrentServer();
 };
 
 #endif  // FLORARPC_EDITOR_H

--- a/ui/Editor.ui
+++ b/ui/Editor.ui
@@ -20,16 +20,22 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QLineEdit" name="serverAddressEdit">
-       <property name="placeholderText">
-        <string>Server address</string>
+      <widget class="QLabel" name="label_7">
+       <property name="text">
+        <string>接続先</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QCheckBox" name="useTlsCheck">
-       <property name="text">
-        <string>TLS</string>
+      <widget class="QComboBox" name="serverSelectBox">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
       </widget>
      </item>

--- a/ui/MainWindow.cpp
+++ b/ui/MainWindow.cpp
@@ -105,6 +105,7 @@ void MainWindow::onActionOpenWorkspaceTriggered() {
 
     protocols.clear();
     imports.clear();
+    servers.clear();
     for (int i = ui.editorTabs->count() - 1; i >= 0; i--) {
         auto editor = ui.editorTabs->widget(i);
         ui.editorTabs->removeTab(i);
@@ -114,6 +115,10 @@ void MainWindow::onActionOpenWorkspaceTriggered() {
 
     for (const auto &importPath : workspace.import_paths()) {
         imports.append(QString::fromStdString(importPath.path()));
+    }
+
+    for (const auto &server : workspace.servers()) {
+        servers.push_back(std::make_shared<Server>(server));
     }
 
     QStringList filenames;
@@ -314,6 +319,11 @@ bool MainWindow::saveWorkspace(const QString &filename) {
     for (auto &path : imports) {
         florarpc::ImportPath *importPath = workspace.add_import_paths();
         importPath->set_path(path.toStdString());
+    }
+
+    for (auto &server : servers) {
+        florarpc::Server *protoServer = workspace.add_servers();
+        server->writeServer(*protoServer);
     }
 
     for (int i = 0; i < ui.editorTabs->count(); i++) {

--- a/ui/MainWindow.cpp
+++ b/ui/MainWindow.cpp
@@ -166,6 +166,12 @@ void MainWindow::onActionManageServerTriggered() {
     dialog->setServers(servers);
     dialog->exec();
     servers = dialog->getServers();
+    for (int i = 0; i < ui.editorTabs->count(); i++) {
+        auto editor = qobject_cast<Editor *>(ui.editorTabs->widget(i));
+        if (editor != nullptr) {
+            editor->setServers(servers);
+        }
+    }
 }
 
 void MainWindow::closeEvent(QCloseEvent *event) {
@@ -286,6 +292,7 @@ Editor *MainWindow::openEditor(std::unique_ptr<Method> method, bool forceNewTab)
     }
 
     auto editor = new Editor(std::move(method), syntaxDefinitions);
+    editor->setServers(servers);
     const auto addedIndex = ui.editorTabs->addTab(editor, QString::fromStdString(methodName));
     ui.editorTabs->setCurrentIndex(addedIndex);
     return editor;

--- a/ui/MainWindow.cpp
+++ b/ui/MainWindow.cpp
@@ -10,6 +10,7 @@
 #include <QTextStream>
 
 #include "ImportsManageDialog.h"
+#include "ServersManageDialog.h"
 #include "flora_constants.h"
 #include "florarpc/workspace.pb.h"
 #include "util/ProtobufIterator.h"
@@ -24,6 +25,7 @@ MainWindow::MainWindow(QWidget *parent)
     connect(ui.actionOpenWorkspace, &QAction::triggered, this, &MainWindow::onActionOpenWorkspaceTriggered);
     connect(ui.actionSaveWorkspace, &QAction::triggered, this, &MainWindow::onActionSaveWorkspaceTriggered);
     connect(ui.actionManageProto, &QAction::triggered, this, &MainWindow::onActionManageProtoTriggered);
+    connect(ui.actionManageServer, &QAction::triggered, this, &MainWindow::onActionManageServerTriggered);
     connect(ui.actionQuit, &QAction::triggered, this, &MainWindow::close);
     connect(ui.treeView, &QTreeView::clicked, this, &MainWindow::onTreeViewClicked);
     connect(ui.treeView, &QWidget::customContextMenuRequested, [=](const QPoint &pos) {
@@ -157,6 +159,13 @@ void MainWindow::onActionManageProtoTriggered() {
     dialog->setPaths(imports);
     dialog->exec();
     imports = dialog->getPaths();
+}
+
+void MainWindow::onActionManageServerTriggered() {
+    auto dialog = std::make_unique<ServersManageDialog>(this);
+    dialog->setServers(servers);
+    dialog->exec();
+    servers = dialog->getServers();
 }
 
 void MainWindow::closeEvent(QCloseEvent *event) {

--- a/ui/MainWindow.h
+++ b/ui/MainWindow.h
@@ -7,6 +7,7 @@
 #include <QShortcut>
 
 #include "../entity/Protocol.h"
+#include "../entity/Server.h"
 #include "Editor.h"
 #include "ProtocolTreeModel.h"
 #include "ui/ui_MainWindow.h"
@@ -33,6 +34,8 @@ private slots:
 
     void onActionManageProtoTriggered();
 
+    void onActionManageServerTriggered();
+
     void onTreeViewClicked(const QModelIndex &index);
 
     void onEditorTabCloseRequested(const int index);
@@ -42,6 +45,7 @@ private slots:
 private:
     Ui::MainWindow ui;
     std::vector<std::shared_ptr<Protocol>> protocols;
+    std::vector<std::shared_ptr<Server>> servers;
     std::unique_ptr<ProtocolTreeModel> protocolTreeModel;
     QStringList imports;
     KSyntaxHighlighting::Repository syntaxDefinitions;

--- a/ui/MainWindow.ui
+++ b/ui/MainWindow.ui
@@ -55,22 +55,23 @@
     <property name="title">
      <string>ファイル(&amp;F)</string>
     </property>
-       <addaction name="actionOpen"/>
-       <addaction name="actionOpenWorkspace"/>
-       <addaction name="separator"/>
-       <addaction name="actionSaveWorkspace"/>
-       <addaction name="separator"/>
-       <addaction name="actionManageProto"/>
-       <addaction name="separator"/>
-       <addaction name="actionQuit"/>
+    <addaction name="actionOpen"/>
+    <addaction name="actionOpenWorkspace"/>
+    <addaction name="separator"/>
+    <addaction name="actionSaveWorkspace"/>
+    <addaction name="separator"/>
+    <addaction name="actionManageProto"/>
+    <addaction name="actionManageServer"/>
+    <addaction name="separator"/>
+    <addaction name="actionQuit"/>
    </widget>
-      <widget class="QMenu" name="menuView">
-          <property name="title">
-              <string>表示(&amp;V)</string>
-          </property>
-      </widget>
-      <addaction name="menuFile"/>
-      <addaction name="menuView"/>
+   <widget class="QMenu" name="menuView">
+    <property name="title">
+     <string>表示(&amp;V)</string>
+    </property>
+   </widget>
+   <addaction name="menuFile"/>
+   <addaction name="menuView"/>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
   <widget class="QDockWidget" name="dockWidget">
@@ -119,80 +120,80 @@
       <widget class="QTreeView" name="treeView">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-            <horstretch>1</horstretch>
-            <verstretch>0</verstretch>
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-          <property name="baseSize">
-              <size>
-                  <width>0</width>
-                  <height>0</height>
-              </size>
-          </property>
-          <property name="contextMenuPolicy">
-              <enum>Qt::CustomContextMenu</enum>
-          </property>
-          <property name="selectionMode">
-              <enum>QAbstractItemView::SingleSelection</enum>
-          </property>
-          <attribute name="headerVisible">
-              <bool>false</bool>
-          </attribute>
+       <property name="baseSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="contextMenuPolicy">
+        <enum>Qt::CustomContextMenu</enum>
+       </property>
+       <property name="selectionMode">
+        <enum>QAbstractItemView::SingleSelection</enum>
+       </property>
+       <attribute name="headerVisible">
+        <bool>false</bool>
+       </attribute>
       </widget>
      </item>
     </layout>
    </widget>
   </widget>
-     <widget class="QDockWidget" name="logDockWidget">
-         <property name="windowTitle">
-             <string>ログ</string>
-         </property>
-         <attribute name="dockWidgetArea">
-             <number>8</number>
-         </attribute>
-         <widget class="QWidget" name="dockWidgetContents_2">
-             <layout class="QHBoxLayout" name="horizontalLayout">
-                 <property name="leftMargin">
-                     <number>0</number>
-                 </property>
-                 <property name="topMargin">
-                     <number>0</number>
-                 </property>
-                 <property name="rightMargin">
-                     <number>0</number>
-                 </property>
-                 <property name="bottomMargin">
-                     <number>0</number>
-                 </property>
-                 <item>
-                     <widget class="QPlainTextEdit" name="logEdit">
-                         <property name="readOnly">
-                             <bool>true</bool>
-                         </property>
-                         <property name="textInteractionFlags">
-                             <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-                         </property>
-                     </widget>
-                 </item>
-             </layout>
-         </widget>
-     </widget>
-     <action name="actionOpen">
-         <property name="text">
-             <string>Protoファイルを開く(&amp;O)...</string>
-         </property>
-         <property name="shortcut">
-             <string>Ctrl+O</string>
-         </property>
-     </action>
-     <action name="actionManageProto">
-         <property name="text">
-             <string>インポート パスの管理(&amp;I)...</string>
-         </property>
-         <property name="shortcut">
-             <string>Ctrl+I</string>
-         </property>
-     </action>
+  <widget class="QDockWidget" name="logDockWidget">
+   <property name="windowTitle">
+    <string>ログ</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>8</number>
+   </attribute>
+   <widget class="QWidget" name="dockWidgetContents_2">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QPlainTextEdit" name="logEdit">
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+  </widget>
+  <action name="actionOpen">
+   <property name="text">
+    <string>Protoファイルを開く(&amp;O)...</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+O</string>
+   </property>
+  </action>
+  <action name="actionManageProto">
+   <property name="text">
+    <string>インポート パスの管理(&amp;I)...</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+I</string>
+   </property>
+  </action>
   <action name="actionQuit">
    <property name="text">
     <string>終了(&amp;Q)</string>
@@ -218,6 +219,14 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+O</string>
+   </property>
+  </action>
+  <action name="actionManageServer">
+   <property name="text">
+    <string>接続先の管理(&amp;E)...</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+E</string>
    </property>
   </action>
  </widget>

--- a/ui/ServerEditDialog.cpp
+++ b/ui/ServerEditDialog.cpp
@@ -1,0 +1,38 @@
+#include "ServerEditDialog.h"
+
+#include <QMessageBox>
+#include <QPushButton>
+
+ServerEditDialog::ServerEditDialog(std::shared_ptr<Server> server, QWidget *parent)
+    : QDialog(parent), server(std::move(server)) {
+    ui.setupUi(this);
+
+    connect(ui.buttonBox->button(QDialogButtonBox::Ok), &QAbstractButton::clicked, this,
+            &ServerEditDialog::onOkButtonClick);
+    connect(ui.buttonBox->button(QDialogButtonBox::Cancel), &QAbstractButton::clicked, this,
+            &ServerEditDialog::onCancelButtonClick);
+
+    ui.nameEdit->setText(this->server->name);
+    ui.addressEdit->setText(this->server->address);
+    ui.useTLSCheck->setChecked(this->server->useTLS);
+}
+
+void ServerEditDialog::onOkButtonClick() {
+    if (ui.nameEdit->text().isEmpty()) {
+        QMessageBox::warning(this, "Error", "接続先名が入力されていません。");
+        return;
+    }
+
+    if (ui.addressEdit->text().isEmpty()) {
+        QMessageBox::warning(this, "Error", "アドレスが入力されていません。");
+        return;
+    }
+
+    server->name = ui.nameEdit->text();
+    server->address = ui.addressEdit->text();
+    server->useTLS = ui.useTLSCheck->isChecked();
+
+    done(Accepted);
+}
+
+void ServerEditDialog::onCancelButtonClick() { done(Rejected); }

--- a/ui/ServerEditDialog.h
+++ b/ui/ServerEditDialog.h
@@ -1,0 +1,25 @@
+#ifndef FLORARPC_SERVEREDITDIALOG_H
+#define FLORARPC_SERVEREDITDIALOG_H
+
+#include <QDialog>
+
+#include "entity/Server.h"
+#include "ui/ui_ServerEditDialog.h"
+
+class ServerEditDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    ServerEditDialog(std::shared_ptr<Server> server, QWidget *parent = nullptr);
+
+private slots:
+    void onOkButtonClick();
+
+    void onCancelButtonClick();
+
+private:
+    Ui::ServerEditDialog ui;
+    std::shared_ptr<Server> server;
+};
+
+#endif  // FLORARPC_SERVEREDITDIALOG_H

--- a/ui/ServerEditDialog.ui
+++ b/ui/ServerEditDialog.ui
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ServerEditDialog</class>
+ <widget class="QDialog" name="ServerEditDialog">
+  <property name="windowModality">
+   <enum>Qt::WindowModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>500</width>
+    <height>220</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>接続先の編集</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="nameEdit"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>アドレス</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>接続先名</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="addressEdit"/>
+     </item>
+     <item row="2" column="1">
+      <widget class="QCheckBox" name="useTLSCheck">
+       <property name="text">
+        <string>&amp;TLSを使用</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/ui/ServersManageDialog.cpp
+++ b/ui/ServersManageDialog.cpp
@@ -1,0 +1,97 @@
+#include "ServersManageDialog.h"
+
+#include <QMessageBox>
+
+#include "ServerEditDialog.h"
+
+ServersManageDialog::ServersManageDialog(QWidget *parent) : QDialog(parent) {
+    ui.setupUi(this);
+
+    connect(ui.addButton, &QAbstractButton::clicked, this, &ServersManageDialog::onAddButtonClick);
+    connect(ui.editButton, &QAbstractButton::clicked, this, &ServersManageDialog::onEditButtonClick);
+    connect(ui.deleteButton, &QAbstractButton::clicked, this, &ServersManageDialog::onDeleteButtonClick);
+    connect(ui.buttonBox->button(QDialogButtonBox::Close), &QAbstractButton::clicked, this,
+            &ServersManageDialog::onCloseButtonClick);
+    connect(ui.tableWidget, &QTableWidget::cellDoubleClicked, this, &ServersManageDialog::onCellDoubleClick);
+
+    auto tableHeader = ui.tableWidget->horizontalHeader();
+    tableHeader->setSectionResizeMode(0, QHeaderView::Stretch);
+    tableHeader->setSectionResizeMode(1, QHeaderView::Stretch);
+    tableHeader->setSectionResizeMode(2, QHeaderView::ResizeToContents);
+}
+
+void ServersManageDialog::setServers(std::vector<std::shared_ptr<Server>> &servers) {
+    this->servers = servers;
+
+    ui.tableWidget->clearContents();
+    for (auto &server : servers) {
+        addServerRow(*server);
+    }
+}
+
+std::vector<std::shared_ptr<Server>> &ServersManageDialog::getServers() { return servers; }
+
+void ServersManageDialog::onAddButtonClick() {
+    auto server = std::make_shared<Server>();
+    auto dialog = std::make_unique<ServerEditDialog>(server, this);
+    if (dialog->exec() == QDialog::DialogCode::Accepted) {
+        servers.push_back(server);
+        addServerRow(*server);
+    }
+}
+
+void ServersManageDialog::onEditButtonClick() {
+    auto select = ui.tableWidget->selectionModel();
+    if (!select->hasSelection()) {
+        return;
+    }
+
+    auto row = select->selectedRows().first();
+    auto server = servers[row.row()];
+    auto dialog = std::make_unique<ServerEditDialog>(server, this);
+    if (dialog->exec() == QDialog::DialogCode::Accepted) {
+        setServerRow(row.row(), *server);
+    }
+}
+
+void ServersManageDialog::onDeleteButtonClick() {
+    auto select = ui.tableWidget->selectionModel();
+    if (!select->hasSelection()) {
+        return;
+    }
+
+    auto row = select->selectedRows().first().row();
+    if (QMessageBox::warning(this, "確認", QString("接続先 %1 を削除してもよろしいですか？").arg(servers[row]->name),
+                             QMessageBox::Ok | QMessageBox::Cancel) != QMessageBox::Ok) {
+        return;
+    }
+
+    ui.tableWidget->removeRow(row);
+    servers.erase(servers.begin() + row);
+}
+
+void ServersManageDialog::onCloseButtonClick() { close(); }
+
+void ServersManageDialog::onCellDoubleClick(int row, int column) {
+    auto server = servers[row];
+    auto dialog = std::make_unique<ServerEditDialog>(server, this);
+    if (dialog->exec() == QDialog::DialogCode::Accepted) {
+        setServerRow(row, *server);
+    }
+}
+
+void ServersManageDialog::addServerRow(Server &server) {
+    int row = ui.tableWidget->rowCount();
+    ui.tableWidget->insertRow(row);
+    setServerRow(row, server);
+}
+
+void ServersManageDialog::setServerRow(int row, Server &server) {
+    ui.tableWidget->setItem(row, 0, new QTableWidgetItem(server.name));
+    ui.tableWidget->setItem(row, 1, new QTableWidgetItem(server.address));
+
+    auto useTLSItem = new QTableWidgetItem();
+    useTLSItem->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
+    useTLSItem->setCheckState(server.useTLS ? Qt::Checked : Qt::Unchecked);
+    ui.tableWidget->setItem(row, 2, useTLSItem);
+}

--- a/ui/ServersManageDialog.h
+++ b/ui/ServersManageDialog.h
@@ -1,0 +1,39 @@
+#ifndef FLORARPC_SERVERSMANAGEDIALOG_H
+#define FLORARPC_SERVERSMANAGEDIALOG_H
+
+#include <QDialog>
+
+#include "entity/Server.h"
+#include "ui/ui_ServersManageDialog.h"
+
+class ServersManageDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit ServersManageDialog(QWidget *parent = nullptr);
+
+    void setServers(std::vector<std::shared_ptr<Server>> &servers);
+
+    std::vector<std::shared_ptr<Server>> &getServers();
+
+private slots:
+    void onAddButtonClick();
+
+    void onEditButtonClick();
+
+    void onDeleteButtonClick();
+
+    void onCloseButtonClick();
+
+    void onCellDoubleClick(int row, int column);
+
+private:
+    Ui::ServersManageDialog ui;
+    std::vector<std::shared_ptr<Server>> servers;
+
+    void addServerRow(Server &server);
+
+    void setServerRow(int row, Server &server);
+};
+
+#endif  // FLORARPC_SERVERSMANAGEDIALOG_H

--- a/ui/ServersManageDialog.ui
+++ b/ui/ServersManageDialog.ui
@@ -27,6 +27,18 @@
        <property name="selectionMode">
         <enum>QAbstractItemView::SingleSelection</enum>
        </property>
+       <property name="selectionBehavior">
+        <enum>QAbstractItemView::SelectRows</enum>
+       </property>
+       <attribute name="horizontalHeaderHighlightSections">
+        <bool>false</bool>
+       </attribute>
+       <attribute name="verticalHeaderVisible">
+        <bool>false</bool>
+       </attribute>
+       <attribute name="verticalHeaderHighlightSections">
+        <bool>false</bool>
+       </attribute>
        <column>
         <property name="text">
          <string>名前</string>
@@ -52,7 +64,9 @@
           <string>追加(&amp;A)</string>
          </property>
          <property name="icon">
-          <iconset theme="list-add"/>
+          <iconset theme="list-add">
+           <normaloff>.</normaloff>.
+          </iconset>
          </property>
         </widget>
        </item>
@@ -62,7 +76,9 @@
           <string>編集(&amp;E)</string>
          </property>
          <property name="icon">
-          <iconset theme="document-edit"/>
+          <iconset theme="document-edit">
+           <normaloff>.</normaloff>.
+          </iconset>
          </property>
         </widget>
        </item>
@@ -72,7 +88,9 @@
           <string>削除(&amp;D)</string>
          </property>
          <property name="icon">
-          <iconset theme="list-remove"/>
+          <iconset theme="list-remove">
+           <normaloff>.</normaloff>.
+          </iconset>
          </property>
         </widget>
        </item>

--- a/ui/ServersManageDialog.ui
+++ b/ui/ServersManageDialog.ui
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ServersManageDialog</class>
+ <widget class="QDialog" name="ServersManageDialog">
+  <property name="windowModality">
+   <enum>Qt::WindowModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>800</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>接続先の管理</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QTableWidget" name="tableWidget">
+       <property name="editTriggers">
+        <set>QAbstractItemView::NoEditTriggers</set>
+       </property>
+       <property name="selectionMode">
+        <enum>QAbstractItemView::SingleSelection</enum>
+       </property>
+       <column>
+        <property name="text">
+         <string>名前</string>
+        </property>
+       </column>
+       <column>
+        <property name="text">
+         <string>アドレス</string>
+        </property>
+       </column>
+       <column>
+        <property name="text">
+         <string>TLS</string>
+        </property>
+       </column>
+      </widget>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QPushButton" name="addButton">
+         <property name="text">
+          <string>追加(&amp;A)</string>
+         </property>
+         <property name="icon">
+          <iconset theme="list-add"/>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="editButton">
+         <property name="text">
+          <string>編集(&amp;E)</string>
+         </property>
+         <property name="icon">
+          <iconset theme="document-edit"/>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="deleteButton">
+         <property name="text">
+          <string>削除(&amp;D)</string>
+         </property>
+         <property name="icon">
+          <iconset theme="list-remove"/>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
fix #44 

接続先アドレスの手打ちボックスとTLSチェックボックスを廃止して、事前に設定を作っておく形式にした。  
表示用の名前、アドレス、TLS使用可否を設定画面で登録した後、リクエストエディター上で選択する。