### PR TITLE
macOSでのウィンドウタイトルをプラットフォームに寄せた表現にする

### DIFF
--- a/ui/MainWindow.cpp
+++ b/ui/MainWindow.cpp
@@ -82,7 +82,7 @@ MainWindow::MainWindow(QWidget *parent)
 
     setGeometry(QStyle::alignedRect(Qt::LeftToRight, Qt::AlignCenter, size(),
                                     QGuiApplication::primaryScreen()->availableGeometry()));
-    setWindowTitle(QString("%1 - FloraRPC").arg("新しいワークスペース"));
+    setWindowTitleWithSuffix("新しいワークスペース");
     reloadCopyAsUserScripts();
 }
 
@@ -453,7 +453,16 @@ bool MainWindow::saveWorkspace(const QString &filename) {
 void MainWindow::setWorkspaceFilename(const QString &filename) {
     workspaceFilename = filename;
     QFileInfo fileInfo(filename);
-    setWindowTitle(QString("%1 - FloraRPC").arg(fileInfo.baseName()));
+    setWindowTitleWithSuffix(fileInfo.fileName());
+    setWindowFilePath(fileInfo.absoluteFilePath());
+}
+
+void MainWindow::setWindowTitleWithSuffix(const QString &title) {
+#ifdef __APPLE__
+    setWindowTitle(title);
+#else
+    setWindowTitle(QString("%1 - FloraRPC").arg(title));
+#endif
 }
 
 void MainWindow::reloadCopyAsUserScripts() {

--- a/ui/MainWindow.h
+++ b/ui/MainWindow.h
@@ -67,6 +67,7 @@ private:
     Editor *openEditor(std::unique_ptr<Method> method, bool forceNewTab);
     bool saveWorkspace(const QString &filename);
     void setWorkspaceFilename(const QString &filename);
+    void setWindowTitleWithSuffix(const QString &title);
     void reloadCopyAsUserScripts();
     void executeCopyAsScript(const QString &script);
 };


### PR DESCRIPTION
`setWindowFilePath` を使うとプロキシアイコンを出せるようになるので、使ってみた。  
あと、macOSのHIGではウィンドウタイトルには書類名のみを表示したほうが良さそうなので、そのようにした。

## New workspace
<img width="630" alt="スクリーンショット 2020-06-29 0 58 13" src="https://user-images.githubusercontent.com/1352154/85952400-005b9b00-b9a4-11ea-8b1d-3aacbb2cfde0.png">

## Saved workspace
<img width="669" alt="スクリーンショット 2020-06-29 0 58 30" src="https://user-images.githubusercontent.com/1352154/85952404-05204f00-b9a4-11ea-9df6-3d81da581f44.png">

もう少し工夫するなら [-[NSFileManager displayNameAtPath:]](https://developer.apple.com/documentation/foundation/nsfilemanager/1409751-displaynameatpath) を使ってFinder設定を考慮して拡張子を削ったりするのも良いかも。とはいえ、開発者ツールを使うような人は拡張子非表示にするのかな、とも思うが、文化を良く知らないのでなんとも。