### PR TITLE
Implement auto save

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,8 @@ add_executable(flora
         entity/Session.h
         entity/Server.cpp
         entity/Server.h
+        ui/event/WorkspaceModifiedEvent.cpp
+        ui/event/WorkspaceModifiedEvent.h
         ui/ProtocolTreeModel.cpp
         ui/ProtocolTreeModel.h
         util/DescriptorPoolProxy.cpp

--- a/ui/Editor.cpp
+++ b/ui/Editor.cpp
@@ -7,6 +7,7 @@
 #include <grpcpp/grpcpp.h>
 
 #include <QClipboard>
+#include <QDebug>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QMenu>

--- a/ui/Editor.cpp
+++ b/ui/Editor.cpp
@@ -7,7 +7,6 @@
 #include <grpcpp/grpcpp.h>
 
 #include <QClipboard>
-#include <QDebug>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QMenu>
@@ -15,6 +14,7 @@
 
 #include "../entity/Method.h"
 #include "../util/GrpcUtility.h"
+#include "event/WorkspaceModifiedEvent.h"
 
 static std::shared_ptr<grpc::ChannelCredentials> getCredentials(
     Server &server, std::vector<std::shared_ptr<Certificate>> &certificates) {
@@ -45,6 +45,10 @@ Editor::Editor(std::unique_ptr<Method> &&method, KSyntaxHighlighting::Repository
             &Editor::onResponseBodyPageChanged);
     connect(ui.prevResponseBodyButton, &QPushButton::clicked, this, &Editor::onPrevResponseBodyButtonClicked);
     connect(ui.nextResponseBodyButton, &QPushButton::clicked, this, &Editor::onNextResponseBodyButtonClicked);
+    connect(ui.serverSelectBox, qOverload<int>(&QComboBox::currentIndexChanged), this,
+            &Editor::willEmitWorkspaceModified);
+    connect(ui.requestEdit, &QTextEdit::textChanged, this, &Editor::willEmitWorkspaceModified);
+    connect(ui.requestMetadataEdit, &QTextEdit::textChanged, this, &Editor::willEmitWorkspaceModified);
 
     // 1:1にする
     // https://stackoverflow.com/a/43835396
@@ -380,6 +384,11 @@ void Editor::cleanupSession() {
     hideStreamingButtons();
     delete session;
     session = nullptr;
+}
+
+void Editor::willEmitWorkspaceModified() {
+    QApplication::postEvent(window(), new Event::WorkspaceModifiedEvent(
+                                          QString("%1:%2").arg(metaObject()->className()).arg(sender()->objectName())));
 }
 
 std::unique_ptr<KSyntaxHighlighting::SyntaxHighlighter> Editor::setupHighlighter(

--- a/ui/Editor.h
+++ b/ui/Editor.h
@@ -64,6 +64,8 @@ private slots:
 
     void cleanupSession();
 
+    void willEmitWorkspaceModified();
+
 private:
     Ui_Editor ui;
     QMenu *responseMetadataContextMenu;

--- a/ui/MainWindow.h
+++ b/ui/MainWindow.h
@@ -5,6 +5,7 @@
 
 #include <QMainWindow>
 #include <QShortcut>
+#include <QTimer>
 
 #include "../entity/Certificate.h"
 #include "../entity/Protocol.h"
@@ -22,6 +23,7 @@ public:
     bool loadWorkspace(const QString &filename);
 
 protected:
+    bool event(QEvent *event) override;
     void closeEvent(QCloseEvent *event) override;
 
 public slots:
@@ -51,6 +53,12 @@ private slots:
 
     void onTabCloseShortcutActivated();
 
+    void onWorkspaceModified();
+
+    void onTimeoutWorkspaceSaveTimer();
+
+    void cancelWorkspaceSaveTimer();
+
 private:
     Ui::MainWindow ui;
     std::vector<std::shared_ptr<Protocol>> protocols;
@@ -63,8 +71,9 @@ private:
     QMenu treeFileContextMenu;
     QMenu treeMethodContextMenu;
     QString workspaceFilename;
+    QTimer workspaceSaveTimer;
 
-    void openProtos(const QStringList &filenames, bool abortOnLoadError);
+    bool openProtos(const QStringList &filenames, bool abortOnLoadError);
     void openMethod(const QModelIndex &index, bool forceNewTab);
     Editor *openEditor(std::unique_ptr<Method> method, bool forceNewTab);
     bool saveWorkspace(const QString &filename);

--- a/ui/event/WorkspaceModifiedEvent.cpp
+++ b/ui/event/WorkspaceModifiedEvent.cpp
@@ -1,0 +1,5 @@
+#include "WorkspaceModifiedEvent.h"
+
+Event::WorkspaceModifiedEvent::WorkspaceModifiedEvent(const QString &sender) : QEvent(type), sender(sender) {}
+
+const QEvent::Type Event::WorkspaceModifiedEvent::type = static_cast<QEvent::Type>(QEvent::User + 1);

--- a/ui/event/WorkspaceModifiedEvent.h
+++ b/ui/event/WorkspaceModifiedEvent.h
@@ -1,0 +1,17 @@
+#ifndef FLORARPC_WORKSPACEMODIFIEDEVENT_H
+#define FLORARPC_WORKSPACEMODIFIEDEVENT_H
+
+#include <QEvent>
+#include <QString>
+
+namespace Event {
+    class WorkspaceModifiedEvent : public QEvent {
+    public:
+        WorkspaceModifiedEvent(const QString &sender);
+
+        const QString sender;
+        static const QEvent::Type type;
+    };
+}  // namespace Event
+
+#endif  // FLORARPC_WORKSPACEMODIFIEDEVENT_H


### PR DESCRIPTION
fix #54 

QEventを使ったのは疎結合にするため。signalのpropagationをやると、今後項目が増えると実装が辛くなるから採用しなかった。