### PR TITLE
Shared metadata

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,7 @@ indent_size = 2
 
 [*.ui]
 indent_size = 1
+ij_xml_text_wrap = off
+ij_any_keep_line_breaks = true
+ij_xml_keep_line_breaks_in_text = true
+ij_xml_keep_whitespaces = true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,9 @@ add_executable(flora
         ui/MainWindow.ui
         ui/MainWindow.cpp
         ui/MainWindow.h
+        ui/MetadataEdit.ui
+        ui/MetadataEdit.cpp
+        ui/MetadataEdit.h
         ui/ImportsManageDialog.ui
         ui/ImportsManageDialog.cpp
         ui/ImportsManageDialog.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,8 @@ add_executable(flora
         util/ProtobufIterator.h
         util/ProtobufJsonPrinter.cpp
         util/ProtobufJsonPrinter.h
+        util/SyntaxHighlighter.cpp
+        util/SyntaxHighlighter.h
         ${FLORA_PROTOBUF_SOURCES}
         ${FLORA_PROTOBUF_HEADERS}
         ${FLORA_PLATFORM_SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,8 @@ add_executable(flora
         entity/Certificate.h
         entity/Protocol.cpp
         entity/Protocol.h
+        entity/Metadata.cpp
+        entity/Metadata.h
         entity/Method.cpp
         entity/Method.h
         entity/Session.cpp

--- a/entity/Metadata.cpp
+++ b/entity/Metadata.cpp
@@ -1,0 +1,43 @@
+#include "Metadata.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+
+QString Metadata::parseJson(const QString& input) {
+    if (!input.isEmpty()) {
+        QJsonParseError parseError = {};
+        QJsonDocument metadataJson = QJsonDocument::fromJson(input.toUtf8(), &parseError);
+        if (metadataJson.isNull()) {
+            return parseError.errorString();
+        }
+        if (!metadataJson.isObject()) {
+            return "Metadata input must be an object.";
+        }
+
+        const QJsonObject& object = metadataJson.object();
+        for (auto iter = object.constBegin(); iter != object.constEnd(); iter++) {
+            const auto key = iter.key();
+            const auto value = iter.value().toString();
+            if (value == nullptr) {
+                return QString("Metadata '%1' must be a string.").arg(key);
+            }
+
+            if (key.endsWith("-bin")) {
+                data.insert(key, QByteArray::fromBase64(value.toUtf8()));
+            } else {
+                data.insert(key, value);
+            }
+        }
+    }
+    return QString();
+}
+
+QHash<QString, QString> Metadata::asHash() {
+    QHash<QString, QString> hash;
+
+    for (auto iter = data.cbegin(); iter != data.cend(); iter++) {
+        hash.insert(iter.key(), iter.value());
+    }
+
+    return hash;
+}

--- a/entity/Metadata.h
+++ b/entity/Metadata.h
@@ -5,13 +5,20 @@
 #include <QMultiMap>
 
 class Metadata {
+    typedef QMultiMap<QString, QString> Container;
+
 public:
-    QString parseJson(const QString &input);
+    enum class MergeStrategy {
+        Preserve,
+        Replace,
+    };
+
+    QString parseJson(const QString &input, MergeStrategy mergeStrategy = MergeStrategy::Preserve);
     inline QMultiMap<QString, QString> getValues() const { return data; }
     QHash<QString, QString> asHash();
 
 private:
-    QMultiMap<QString, QString> data;
+    Container data;
 };
 
 #endif  // FLORARPC_METADATA_H

--- a/entity/Metadata.h
+++ b/entity/Metadata.h
@@ -1,0 +1,17 @@
+#ifndef FLORARPC_METADATA_H
+#define FLORARPC_METADATA_H
+
+#include <QHash>
+#include <QMultiMap>
+
+class Metadata {
+public:
+    QString parseJson(const QString &input);
+    inline QMultiMap<QString, QString> getValues() const { return data; }
+    QHash<QString, QString> asHash();
+
+private:
+    QMultiMap<QString, QString> data;
+};
+
+#endif  // FLORARPC_METADATA_H

--- a/entity/Server.cpp
+++ b/entity/Server.cpp
@@ -2,14 +2,15 @@
 
 Server::Server() : Server(QUuid::createUuid()) {}
 
-Server::Server(QUuid id) : id(id), name(), address(), useTLS(false), certificateUUID() {}
+Server::Server(QUuid id) : id(id), name(), address(), useTLS(false), certificateUUID(), sharedMetadata() {}
 
 Server::Server(const florarpc::Server& server)
     : id(QByteArray::fromStdString(server.id())),
       name(QString::fromStdString(server.name())),
       address(QString::fromStdString(server.address())),
       useTLS(server.usetls()),
-      certificateUUID(QByteArray::fromStdString(server.certificate_id())) {}
+      certificateUUID(QByteArray::fromStdString(server.certificate_id())),
+      sharedMetadata(QString::fromStdString(server.shared_metadata())) {}
 
 void Server::writeServer(florarpc::Server& server) {
     server.set_id(id.toString().toStdString());
@@ -17,6 +18,7 @@ void Server::writeServer(florarpc::Server& server) {
     server.set_address(address.toStdString());
     server.set_usetls(useTLS);
     server.set_certificate_id(certificateUUID.toString().toStdString());
+    server.set_shared_metadata(sharedMetadata.toStdString());
 }
 
 std::shared_ptr<Certificate> Server::findCertificate(const std::vector<std::shared_ptr<Certificate>>& certificates) {

--- a/entity/Server.h
+++ b/entity/Server.h
@@ -22,6 +22,7 @@ public:
     QString address;
     bool useTLS;
     QUuid certificateUUID;
+    QString sharedMetadata;
 };
 
 #endif  // FLORARPC_SERVER_H

--- a/proto/florarpc/workspace.proto
+++ b/proto/florarpc/workspace.proto
@@ -33,6 +33,7 @@ message Request {
   string body_draft = 2;
   string metadata_draft = 3;
   string selected_server_id = 4;
+  bool use_shared_metadata = 5;
 }
 
 message Server {
@@ -41,6 +42,7 @@ message Server {
   string address = 3;
   bool useTLS = 4;
   string certificate_id = 5;
+  string shared_metadata = 6;
 }
 
 message Certificate {

--- a/ui/Editor.cpp
+++ b/ui/Editor.cpp
@@ -163,7 +163,8 @@ QString Editor::getRequestBody() { return ui.requestEdit->toPlainText(); }
 
 std::optional<QHash<QString, QString>> Editor::getMetadata() {
     Metadata meta;
-    if (auto server = getCurrentServer(); server && !server->sharedMetadata.isEmpty()) {
+    if (auto server = getCurrentServer();
+        server && !server->sharedMetadata.isEmpty() && ui.useSharedMetadata->isChecked()) {
         if (auto parseResult = meta.parseJson(server->sharedMetadata); !parseResult.isEmpty()) {
             QMessageBox::warning(this, "Shared Metadata Parse Error", parseResult);
             return std::nullopt;
@@ -203,7 +204,8 @@ void Editor::onExecuteButtonClicked() {
 
     // Parse request metadata
     Metadata meta;
-    if (auto server = getCurrentServer(); server && !server->sharedMetadata.isEmpty()) {
+    if (auto server = getCurrentServer();
+        server && !server->sharedMetadata.isEmpty() && ui.useSharedMetadata->isChecked()) {
         if (auto parseResult = meta.parseJson(server->sharedMetadata); !parseResult.isEmpty()) {
             setErrorToResponseView("-", "Shared Metadata Parse Error", parseResult);
             return;

--- a/ui/Editor.cpp
+++ b/ui/Editor.cpp
@@ -150,6 +150,7 @@ void Editor::readRequest(const florarpc::Request &request) {
             break;
         }
     }
+    ui.useSharedMetadata->setChecked(request.use_shared_metadata());
 }
 
 void Editor::writeRequest(florarpc::Request &request) {
@@ -163,6 +164,7 @@ void Editor::writeRequest(florarpc::Request &request) {
     } else {
         request.clear_selected_server_id();
     }
+    request.set_use_shared_metadata(ui.useSharedMetadata->isChecked());
 }
 
 QString Editor::getRequestBody() { return ui.requestEdit->toPlainText(); }

--- a/ui/Editor.cpp
+++ b/ui/Editor.cpp
@@ -169,7 +169,8 @@ std::optional<QHash<QString, QString>> Editor::getMetadata() {
             return std::nullopt;
         }
     }
-    if (auto parseResult = meta.parseJson(ui.requestMetadataEdit->toString()); !parseResult.isEmpty()) {
+    if (auto parseResult = meta.parseJson(ui.requestMetadataEdit->toString(), Metadata::MergeStrategy::Replace);
+        !parseResult.isEmpty()) {
         QMessageBox::warning(this, "Request Metadata Parse Error", parseResult);
         return std::nullopt;
     }
@@ -208,7 +209,8 @@ void Editor::onExecuteButtonClicked() {
             return;
         }
     }
-    if (auto parseResult = meta.parseJson(ui.requestMetadataEdit->toString()); !parseResult.isEmpty()) {
+    if (auto parseResult = meta.parseJson(ui.requestMetadataEdit->toString(), Metadata::MergeStrategy::Replace);
+        !parseResult.isEmpty()) {
         setErrorToResponseView("-", "Request Metadata Parse Error", parseResult);
         return;
     }

--- a/ui/Editor.h
+++ b/ui/Editor.h
@@ -20,7 +20,7 @@ class Editor : public QWidget {
     Q_OBJECT
 
 public:
-    Editor(std::unique_ptr<Method> &&method, KSyntaxHighlighting::Repository &repository, QWidget *parent = nullptr);
+    Editor(std::unique_ptr<Method> &&method, QWidget *parent = nullptr);
 
     inline Method &getMethod() { return *method; }
 
@@ -79,9 +79,6 @@ private:
     std::unique_ptr<KSyntaxHighlighting::SyntaxHighlighter> requestHighlighter;
     std::unique_ptr<KSyntaxHighlighting::SyntaxHighlighter> requestMetadataHighlighter;
     std::unique_ptr<KSyntaxHighlighting::SyntaxHighlighter> responseHighlighter;
-
-    std::unique_ptr<KSyntaxHighlighting::SyntaxHighlighter> setupHighlighter(
-        QTextEdit &edit, const KSyntaxHighlighting::Definition &definition, const KSyntaxHighlighting::Theme &theme);
 
     void addMetadataRow(const QString &key, const QString &value);
 

--- a/ui/Editor.ui
+++ b/ui/Editor.ui
@@ -164,8 +164,7 @@
             <widget class="QCheckBox" name="useSharedMetadata">
              <property name="toolTip">
               <string>接続先設定で入力されている共通メタデータを使用します。
-               同じ名前のメタデータがある場合は、この下に書いた値が優先されます。
-              </string>
+同じ名前のメタデータがある場合は、この下に書いた値が優先されます。</string>
              </property>
              <property name="text">
               <string>接続先の共通メタデータを使用</string>
@@ -178,9 +177,7 @@
               <bool>false</bool>
              </property>
              <property name="placeholderText">
-              <string>{&quot;text-meta&quot;: &quot;value&quot;, &quot;binary-meta-bin&quot;: &quot;base64 value&quot;,
-               ...}
-              </string>
+              <string>{&quot;text-meta&quot;: &quot;value&quot;, &quot;binary-meta-bin&quot;: &quot;base64 value&quot;, ...}</string>
              </property>
             </widget>
            </item>

--- a/ui/Editor.ui
+++ b/ui/Editor.ui
@@ -169,6 +169,9 @@
              <property name="text">
               <string>接続先の共通メタデータを使用</string>
              </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
             </widget>
            </item>
            <item>

--- a/ui/Editor.ui
+++ b/ui/Editor.ui
@@ -172,12 +172,12 @@
             </widget>
            </item>
            <item>
-            <widget class="QTextEdit" name="requestMetadataEdit">
-             <property name="acceptRichText">
-              <bool>false</bool>
-             </property>
-             <property name="placeholderText">
-              <string>{&quot;text-meta&quot;: &quot;value&quot;, &quot;binary-meta-bin&quot;: &quot;base64 value&quot;, ...}</string>
+            <widget class="MetadataEdit" name="requestMetadataEdit" native="true">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
              </property>
             </widget>
            </item>
@@ -475,6 +475,12 @@
    <class>MultiPageJsonView</class>
    <extends>QWidget</extends>
    <header>ui/MultiPageJsonView.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MetadataEdit</class>
+   <extends>QWidget</extends>
+   <header>ui/MetadataEdit.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/ui/Editor.ui
+++ b/ui/Editor.ui
@@ -161,12 +161,26 @@
           </attribute>
           <layout class="QVBoxLayout" name="verticalLayout_10">
            <item>
+            <widget class="QCheckBox" name="useSharedMetadata">
+             <property name="toolTip">
+              <string>接続先設定で入力されている共通メタデータを使用します。
+               同じ名前のメタデータがある場合は、この下に書いた値が優先されます。
+              </string>
+             </property>
+             <property name="text">
+              <string>接続先の共通メタデータを使用</string>
+             </property>
+            </widget>
+           </item>
+           <item>
             <widget class="QTextEdit" name="requestMetadataEdit">
              <property name="acceptRichText">
               <bool>false</bool>
              </property>
              <property name="placeholderText">
-              <string>{&quot;text-meta&quot;: &quot;value&quot;, &quot;binary-meta-bin&quot;: &quot;base64 value&quot;, ...}</string>
+              <string>{&quot;text-meta&quot;: &quot;value&quot;, &quot;binary-meta-bin&quot;: &quot;base64 value&quot;,
+               ...}
+              </string>
              </property>
             </widget>
            </item>

--- a/ui/MainWindow.cpp
+++ b/ui/MainWindow.cpp
@@ -366,7 +366,7 @@ Editor *MainWindow::openEditor(std::unique_ptr<Method> method, bool forceNewTab)
         }
     }
 
-    auto editor = new Editor(std::move(method), syntaxDefinitions);
+    auto editor = new Editor(std::move(method));
     editor->setServers(servers);
     editor->setCertificates(certificates);
     const auto addedIndex = ui.editorTabs->addTab(editor, QString::fromStdString(methodName));

--- a/ui/MainWindow.h
+++ b/ui/MainWindow.h
@@ -1,8 +1,6 @@
 #ifndef FLORARPC_MAINWINDOW_H
 #define FLORARPC_MAINWINDOW_H
 
-#include <KSyntaxHighlighting/repository.h>
-
 #include <QMainWindow>
 #include <QShortcut>
 #include <QTimer>
@@ -66,7 +64,6 @@ private:
     std::vector<std::shared_ptr<Certificate>> certificates;
     std::unique_ptr<ProtocolTreeModel> protocolTreeModel;
     QStringList imports;
-    KSyntaxHighlighting::Repository syntaxDefinitions;
     QShortcut tabCloseShortcut;
     QMenu treeFileContextMenu;
     QMenu treeMethodContextMenu;

--- a/ui/MetadataEdit.cpp
+++ b/ui/MetadataEdit.cpp
@@ -1,0 +1,86 @@
+#include "MetadataEdit.h"
+
+#include <QFontDatabase>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <chrono>
+
+MetadataEdit::MetadataEdit(QWidget *parent) : QWidget(parent), validateTimer(this), valid(true), metadata() {
+    ui.setupUi(this);
+
+    connect(ui.textEdit, &QTextEdit::textChanged, this, &MetadataEdit::onTextChanged);
+    connect(&validateTimer, &QTimer::timeout, this, &MetadataEdit::onValidateTimerTimeout);
+
+    const auto fixedFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+    ui.textEdit->setFont(fixedFont);
+    ui.error->hide();
+
+    validateTimer.setSingleShot(true);
+}
+
+bool MetadataEdit::isValid() {
+    if (validateTimer.isActive()) {
+        validateTimer.stop();
+        onValidateTimerTimeout();
+    }
+
+    return valid;
+}
+
+QString MetadataEdit::toString() { return ui.textEdit->toPlainText(); }
+
+void MetadataEdit::setString(const QString &metadata) { ui.textEdit->setText(metadata); }
+
+Session::Metadata MetadataEdit::toMap() {
+    if (validateTimer.isActive()) {
+        validateTimer.stop();
+        onValidateTimerTimeout();
+    }
+
+    return metadata;
+}
+
+void MetadataEdit::onTextChanged() { validateTimer.start(std::chrono::seconds(3)); }
+
+void MetadataEdit::onValidateTimerTimeout() {
+    valid = true;
+    ui.error->setText("");
+    ui.error->hide();
+    metadata.clear();
+
+    if (const auto metadataInput = ui.textEdit->toPlainText(); !metadataInput.isEmpty()) {
+        QJsonParseError parseError = {};
+        QJsonDocument metadataJson = QJsonDocument::fromJson(metadataInput.toUtf8(), &parseError);
+        if (metadataJson.isNull()) {
+            valid = false;
+            ui.error->setText(QString("<b>Invalid metadata</b> %1").arg(parseError.errorString()));
+            ui.error->show();
+            return;
+        }
+        if (!metadataJson.isObject()) {
+            valid = false;
+            ui.error->setText("<b>Invalid metadata</b> Input must be a json object.");
+            ui.error->show();
+            return;
+        }
+
+        const QJsonObject &object = metadataJson.object();
+        for (auto iter = object.constBegin(); iter != object.constEnd(); iter++) {
+            const auto key = iter.key();
+            const auto value = iter.value().toString();
+            if (value == nullptr) {
+                valid = false;
+                metadata.clear();
+                ui.error->setText(QString("<b>Invalid metadata</b> Metadata '%1' must be a string.").arg(key));
+                ui.error->show();
+                return;
+            }
+
+            if (key.endsWith("-bin")) {
+                metadata.insert(key, QByteArray::fromBase64(value.toUtf8()));
+            } else {
+                metadata.insert(key, value);
+            }
+        }
+    }
+}

--- a/ui/MetadataEdit.h
+++ b/ui/MetadataEdit.h
@@ -6,6 +6,7 @@
 #include <QTimer>
 #include <QWidget>
 
+#include "entity/Metadata.h"
 #include "entity/Session.h"
 #include "ui/ui_MetadataEdit.h"
 
@@ -32,7 +33,7 @@ private:
     QTimer *validateTimer;
 
     bool valid;
-    Session::Metadata metadata;
+    std::unique_ptr<Metadata> metadata;
 };
 
 #endif  // FLORARPC_METADATAEDIT_H

--- a/ui/MetadataEdit.h
+++ b/ui/MetadataEdit.h
@@ -1,6 +1,8 @@
 #ifndef FLORARPC_METADATAEDIT_H
 #define FLORARPC_METADATAEDIT_H
 
+#include <KSyntaxHighlighting/syntaxhighlighter.h>
+
 #include <QTimer>
 #include <QWidget>
 
@@ -17,13 +19,18 @@ public:
     void setString(const QString &metadata);
     Session::Metadata toMap();
 
+signals:
+    void changed();
+
 private slots:
     void onTextChanged();
     void onValidateTimerTimeout();
 
 private:
     Ui_MetadataEdit ui;
-    QTimer validateTimer;
+    std::unique_ptr<KSyntaxHighlighting::SyntaxHighlighter> highlighter;
+    QTimer *validateTimer;
+
     bool valid;
     Session::Metadata metadata;
 };

--- a/ui/MetadataEdit.h
+++ b/ui/MetadataEdit.h
@@ -1,0 +1,31 @@
+#ifndef FLORARPC_METADATAEDIT_H
+#define FLORARPC_METADATAEDIT_H
+
+#include <QTimer>
+#include <QWidget>
+
+#include "entity/Session.h"
+#include "ui/ui_MetadataEdit.h"
+
+class MetadataEdit : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit MetadataEdit(QWidget *parent = nullptr);
+    bool isValid();
+    QString toString();
+    void setString(const QString &metadata);
+    Session::Metadata toMap();
+
+private slots:
+    void onTextChanged();
+    void onValidateTimerTimeout();
+
+private:
+    Ui_MetadataEdit ui;
+    QTimer validateTimer;
+    bool valid;
+    Session::Metadata metadata;
+};
+
+#endif  // FLORARPC_METADATAEDIT_H

--- a/ui/MetadataEdit.ui
+++ b/ui/MetadataEdit.ui
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MetadataEdit</class>
+ <widget class="QWidget" name="MetadataEdit">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>6</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QTextEdit" name="textEdit">
+     <property name="acceptRichText">
+      <bool>false</bool>
+     </property>
+     <property name="placeholderText">
+      <string>{&quot;text-meta&quot;: &quot;value&quot;, &quot;binary-meta-bin&quot;: &quot;base64 value&quot;, ...}</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="error">
+     <property name="styleSheet">
+      <string notr="true">border: 1px solid #cc6666;
+border-radius: 3px;
+background-color: rgba(220, 128, 128, 128)</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="margin">
+      <number>2</number>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/ui/MultiPageJsonView.cpp
+++ b/ui/MultiPageJsonView.cpp
@@ -1,6 +1,6 @@
 #include "MultiPageJsonView.h"
-#include <KSyntaxHighlighting/definition.h>
-#include <KSyntaxHighlighting/theme.h>
+
+#include "util/SyntaxHighlighter.h"
 
 MultiPageJsonView::MultiPageJsonView(QWidget *parent) : QWidget(parent) {
     ui.setupUi(this);
@@ -10,32 +10,12 @@ MultiPageJsonView::MultiPageJsonView(QWidget *parent) : QWidget(parent) {
     connect(ui.prevButton, &QPushButton::clicked, this, &MultiPageJsonView::onPrevButtonClicked);
     connect(ui.nextButton, &QPushButton::clicked, this, &MultiPageJsonView::onNextButtonClicked);
 
+    highlighter = SyntaxHighlighter::setup(*ui.textEdit, palette());
+
     const auto fixedFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
     ui.textEdit->setFont(fixedFont);
 
     ui.pager->setDisabled(true);
-}
-
-void MultiPageJsonView::setupHighlighter(KSyntaxHighlighting::Repository &repository) {
-    const auto jsonDefinition = repository.definitionForMimeType("application/json");
-    if (jsonDefinition.isValid()) {
-        const auto theme = (palette().color(QPalette::Base).lightness() < 128) ?
-                           repository.defaultTheme(KSyntaxHighlighting::Repository::DarkTheme) :
-                           repository.defaultTheme(KSyntaxHighlighting::Repository::LightTheme);
-
-        highlighter = std::make_unique<KSyntaxHighlighting::SyntaxHighlighter>(ui.textEdit);
-
-        auto pal = qApp->palette();
-        if (theme.isValid()) {
-            pal.setColor(QPalette::Base, theme.editorColor(KSyntaxHighlighting::Theme::BackgroundColor));
-            pal.setColor(QPalette::Highlight, theme.editorColor(KSyntaxHighlighting::Theme::TextSelection));
-        }
-        setPalette(pal);
-
-        highlighter->setDefinition(jsonDefinition);
-        highlighter->setTheme(theme);
-        highlighter->rehighlight();
-    }
 }
 
 void MultiPageJsonView::clear() {

--- a/ui/MultiPageJsonView.h
+++ b/ui/MultiPageJsonView.h
@@ -3,7 +3,6 @@
 
 #include <QWidget>
 #include <KSyntaxHighlighting/syntaxhighlighter.h>
-#include <KSyntaxHighlighting/repository.h>
 #include "ui/ui_MultiPageJsonView.h"
 
 class MultiPageJsonView : public QWidget {
@@ -11,8 +10,6 @@ Q_OBJECT
 
 public:
     explicit MultiPageJsonView(QWidget *parent = nullptr);
-
-    void setupHighlighter(KSyntaxHighlighting::Repository &repository);
 
 signals:
 

--- a/ui/ServerEditDialog.cpp
+++ b/ui/ServerEditDialog.cpp
@@ -19,6 +19,7 @@ ServerEditDialog::ServerEditDialog(std::shared_ptr<Server> server,
     ui.nameEdit->setText(this->server->name);
     ui.addressEdit->setText(this->server->address);
     ui.useTLSCheck->setChecked(this->server->useTLS);
+    ui.sharedMetadataEdit->setString(this->server->sharedMetadata);
 
     ui.certificateComboBox->setEnabled(this->server->useTLS);
     ui.certificateComboBox->addItem("(指定なし)");
@@ -48,6 +49,11 @@ void ServerEditDialog::onOkButtonClick() {
         return;
     }
 
+    if (!ui.sharedMetadataEdit->isValid()) {
+        QMessageBox::warning(this, "Error", "共通メタデータに入力エラーがあります。");
+        return;
+    }
+
     server->name = ui.nameEdit->text();
     server->address = ui.addressEdit->text();
     server->useTLS = ui.useTLSCheck->isChecked();
@@ -56,6 +62,7 @@ void ServerEditDialog::onOkButtonClick() {
     } else {
         server->certificateUUID = QUuid();
     }
+    server->sharedMetadata = ui.sharedMetadataEdit->toString();
 
     done(Accepted);
 }

--- a/ui/ServerEditDialog.ui
+++ b/ui/ServerEditDialog.ui
@@ -86,13 +86,12 @@
     </widget>
    </item>
    <item>
-    <widget class="QTextEdit" name="sharedMetadataEdit">
-     <property name="acceptRichText">
-      <bool>false</bool>
-     </property>
-     <property name="placeholderText">
-      <string>{&quot;text-meta&quot;: &quot;value&quot;, &quot;binary-meta-bin&quot;: &quot;base64 value&quot;, ...}
-      </string>
+    <widget class="MetadataEdit" name="sharedMetadataEdit" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
     </widget>
    </item>
@@ -105,6 +104,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>MetadataEdit</class>
+   <extends>QWidget</extends>
+   <header>ui/MetadataEdit.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>nameEdit</tabstop>
   <tabstop>addressEdit</tabstop>

--- a/ui/ServerEditDialog.ui
+++ b/ui/ServerEditDialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>500</width>
-    <height>200</height>
+    <height>500</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -67,13 +67,34 @@
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>40</height>
+       <height>6</height>
       </size>
      </property>
     </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>共通メタデータ &lt;small&gt;この接続先を使う際、常に送信したいメタデータを定義できます。&lt;/small&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTextEdit" name="sharedMetadataEdit">
+     <property name="acceptRichText">
+      <bool>false</bool>
+     </property>
+     <property name="placeholderText">
+      <string>{&quot;text-meta&quot;: &quot;value&quot;, &quot;binary-meta-bin&quot;: &quot;base64 value&quot;, ...}
+      </string>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">

--- a/util/SyntaxHighlighter.cpp
+++ b/util/SyntaxHighlighter.cpp
@@ -1,0 +1,32 @@
+#include "SyntaxHighlighter.h"
+
+#include <QApplication>
+#include <KSyntaxHighlighting/definition.h>
+#include <KSyntaxHighlighting/repository.h>
+#include <KSyntaxHighlighting/theme.h>
+
+std::unique_ptr<KSyntaxHighlighting::SyntaxHighlighter> SyntaxHighlighter::setup(QTextEdit& textEdit, const QPalette &palette) {
+    static KSyntaxHighlighting::Repository repository;
+    static auto jsonDefinition = repository.definitionForMimeType("application/json");
+
+    if (!jsonDefinition.isValid()) {
+        return nullptr;
+    }
+
+    const auto theme = (palette.color(QPalette::Base).lightness() < 128)
+                       ? repository.defaultTheme(KSyntaxHighlighting::Repository::DarkTheme)
+                       : repository.defaultTheme(KSyntaxHighlighting::Repository::LightTheme);
+    auto highlighter = std::make_unique<KSyntaxHighlighting::SyntaxHighlighter>(&textEdit);
+    auto pal = qApp->palette();
+    if (theme.isValid()) {
+        pal.setColor(QPalette::Base, theme.editorColor(KSyntaxHighlighting::Theme::BackgroundColor));
+        pal.setColor(QPalette::Highlight, theme.editorColor(KSyntaxHighlighting::Theme::TextSelection));
+    }
+    textEdit.setPalette(pal);
+
+    highlighter->setDefinition(jsonDefinition);
+    highlighter->setTheme(theme);
+    highlighter->rehighlight();
+
+    return highlighter;
+}

--- a/util/SyntaxHighlighter.h
+++ b/util/SyntaxHighlighter.h
@@ -1,0 +1,14 @@
+#ifndef FLORARPC_SYNTAXHIGHLIGHTER_H
+#define FLORARPC_SYNTAXHIGHLIGHTER_H
+
+#include <KSyntaxHighlighting/syntaxhighlighter.h>
+
+#include <QTextEdit>
+#include <memory>
+
+class SyntaxHighlighter {
+public:
+    static std::unique_ptr<KSyntaxHighlighting::SyntaxHighlighter> setup(QTextEdit &textEdit, const QPalette &palette);
+};
+
+#endif  // FLORARPC_SYNTAXHIGHLIGHTER_H


### PR DESCRIPTION
fix #75 

ServerごとにShared metadataを設定できるようにする。必要に応じて、Requestごとに値の上書き、またはShared metadataを一切使用しない選択もできる。