### PR TITLE
Import from folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ if(WIN32)
   add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
 endif()
 
-find_package(Qt5 COMPONENTS Widgets Qml REQUIRED)
+find_package(Qt5 COMPONENTS Widgets Qml Concurrent REQUIRED)
 
 option(FLORA_FORCE_BUILD_KF5LIB "システムのKF5ライブラリを使用せず、常にビルドする")
 if(NOT FLORA_FORCE_BUILD_KF5LIB)
@@ -171,6 +171,7 @@ add_executable(flora
 target_link_libraries(flora
         Qt5::Widgets
         Qt5::Qml
+        Qt5::Concurrent
         KF5::SyntaxHighlighting
         protobuf::libprotobuf
         ${LIB_gRPC})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ if(WIN32)
   add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
 endif()
 
-find_package(Qt5 COMPONENTS Widgets Qml Concurrent REQUIRED)
+find_package(Qt5 COMPONENTS Widgets Qml REQUIRED)
 
 option(FLORA_FORCE_BUILD_KF5LIB "システムのKF5ライブラリを使用せず、常にビルドする")
 if(NOT FLORA_FORCE_BUILD_KF5LIB)
@@ -173,7 +173,6 @@ add_executable(flora
 target_link_libraries(flora
         Qt5::Widgets
         Qt5::Qml
-        Qt5::Concurrent
         KF5::SyntaxHighlighting
         protobuf::libprotobuf
         ${LIB_gRPC})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,8 @@ add_executable(flora
         entity/Server.h
         ui/event/WorkspaceModifiedEvent.cpp
         ui/event/WorkspaceModifiedEvent.h
+        ui/task/ImportProtosTask.cpp
+        ui/task/ImportProtosTask.h
         ui/ProtocolTreeModel.cpp
         ui/ProtocolTreeModel.h
         util/DescriptorPoolProxy.cpp

--- a/ui/MainWindow.cpp
+++ b/ui/MainWindow.cpp
@@ -218,6 +218,8 @@ void MainWindow::onAsyncLoadFinished(const QList<std::shared_ptr<Protocol>> &pro
         ui.logDockWidget->show();
         QMessageBox::critical(this, "Load error",
                               "Protoファイルの読込中にエラーが発生しました。\n詳細はログを確認してください。");
+    } else if (protocols.isEmpty()) {
+        QMessageBox::warning(this, "Load error", "Protoファイルが見つからないか、すでに全てインポートされています。");
     }
 }
 

--- a/ui/MainWindow.cpp
+++ b/ui/MainWindow.cpp
@@ -401,9 +401,9 @@ bool MainWindow::bulkOpenProtos(const QStringList &filenames) {
     }
 
     if (error) {
+        ui.logDockWidget->show();
         QMessageBox::critical(this, "Load error",
                               "Protoファイルの読込中にエラーが発生しました。\n詳細はログを確認してください。");
-        ui.logDockWidget->show();
     }
 
     return true;

--- a/ui/MainWindow.cpp
+++ b/ui/MainWindow.cpp
@@ -116,18 +116,22 @@ void MainWindow::onActionOpenDirectoryTriggered() {
         return;
     }
 
-    QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
-
     QStringList filenames;
-    QDirIterator iterator(dirname, QStringList() << "*.proto", QDir::Files, QDirIterator::Subdirectories);
-    while (iterator.hasNext()) {
-        filenames << iterator.next();
+    {
+        QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
+        QDirIterator iterator(dirname, QStringList() << "*.proto", QDir::Files, QDirIterator::Subdirectories);
+        while (iterator.hasNext()) {
+            filenames << iterator.next();
+        }
+        QApplication::restoreOverrideCursor();
     }
+    if (filenames.isEmpty()) {
+        return;
+    }
+
     if (openProtos(filenames, false)) {
         onWorkspaceModified();
     }
-
-    QApplication::restoreOverrideCursor();
 }
 
 void MainWindow::onActionOpenWorkspaceTriggered() {

--- a/ui/MainWindow.cpp
+++ b/ui/MainWindow.cpp
@@ -10,6 +10,7 @@
 #include <QFutureWatcher>
 #include <QJSEngine>
 #include <QMessageBox>
+#include <QProgressDialog>
 #include <QScreen>
 #include <QStandardPaths>
 #include <QStyle>
@@ -117,19 +118,14 @@ void MainWindow::onActionOpenDirectoryTriggered() {
         return;
     }
 
-    const auto loadingMessage = new QMessageBox(this);
-    loadingMessage->setWindowTitle("Loading");
-    loadingMessage->setText("読み込み中 しばらくお待ちください...");
-    loadingMessage->setIcon(QMessageBox::Information);
-    loadingMessage->setWindowFlag(Qt::Sheet);
-    loadingMessage->setWindowFlags(Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::Sheet);
-    loadingMessage->setStandardButtons(QMessageBox::NoButton);
-    loadingMessage->show();
-    connect(loadingMessage, &QDialog::accepted, loadingMessage, &QDialog::deleteLater);
-
+    const auto progressDialog = new QProgressDialog("読み込み中...", QString(), 0, 0, this,
+                                                    Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::Sheet);
+    progressDialog->setWindowModality(Qt::WindowModal);
+    progressDialog->show();
+    connect(progressDialog, &QDialog::accepted, progressDialog, &QDialog::deleteLater);
     const auto watcher = new QFutureWatcher<QStringList>(this);
     connect(watcher, &QFutureWatcher<QStringList>::finished, [=]() {
-        loadingMessage->accept();
+        progressDialog->accept();
         if (watcher->result().isEmpty()) {
             return;
         }

--- a/ui/MainWindow.h
+++ b/ui/MainWindow.h
@@ -31,6 +31,8 @@ private slots:
 
     void onActionOpenTriggered();
 
+    void onActionOpenDirectoryTriggered();
+
     void onActionOpenWorkspaceTriggered();
 
     void onActionSaveWorkspaceTriggered();

--- a/ui/MainWindow.h
+++ b/ui/MainWindow.h
@@ -1,6 +1,7 @@
 #ifndef FLORARPC_MAINWINDOW_H
 #define FLORARPC_MAINWINDOW_H
 
+#include <QDirIterator>
 #include <QMainWindow>
 #include <QShortcut>
 #include <QTimer>
@@ -73,6 +74,7 @@ private:
     QTimer workspaceSaveTimer;
 
     bool openProtos(const QStringList &filenames, bool abortOnLoadError);
+    bool bulkOpenProtos(const QStringList &filenames);
     void openMethod(const QModelIndex &index, bool forceNewTab);
     Editor *openEditor(std::unique_ptr<Method> method, bool forceNewTab);
     bool saveWorkspace(const QString &filename);

--- a/ui/MainWindow.h
+++ b/ui/MainWindow.h
@@ -1,7 +1,6 @@
 #ifndef FLORARPC_MAINWINDOW_H
 #define FLORARPC_MAINWINDOW_H
 
-#include <QDirIterator>
 #include <QMainWindow>
 #include <QShortcut>
 #include <QTimer>
@@ -46,6 +45,8 @@ private slots:
 
     void onActionOpenCopyAsUserScriptDirTriggered();
 
+    void onAsyncLoadFinished(const QList<std::shared_ptr<Protocol>> &protocols, bool hasError);
+
     void onTreeViewClicked(const QModelIndex &index);
 
     void onRemoveFileFromTreeTriggered();
@@ -74,7 +75,6 @@ private:
     QTimer workspaceSaveTimer;
 
     bool openProtos(const QStringList &filenames, bool abortOnLoadError);
-    bool bulkOpenProtos(const QStringList &filenames);
     void openMethod(const QModelIndex &index, bool forceNewTab);
     Editor *openEditor(std::unique_ptr<Method> method, bool forceNewTab);
     bool saveWorkspace(const QString &filename);

--- a/ui/MainWindow.ui
+++ b/ui/MainWindow.ui
@@ -56,6 +56,7 @@
      <string>ファイル(&amp;F)</string>
     </property>
     <addaction name="actionOpen"/>
+    <addaction name="actionOpenDirectory"/>
     <addaction name="separator"/>
     <addaction name="actionOpenWorkspace"/>
     <addaction name="actionSaveWorkspace"/>
@@ -267,6 +268,11 @@
   <action name="actionOpenCopyAsUserScriptDir">
    <property name="text">
     <string>スクリプトフォルダを開く(&amp;O)</string>
+   </property>
+  </action>
+  <action name="actionOpenDirectory">
+   <property name="text">
+    <string>フォルダからProtoファイルを取り込む(&amp;F)...</string>
    </property>
   </action>
  </widget>

--- a/ui/task/ImportProtosTask.cpp
+++ b/ui/task/ImportProtosTask.cpp
@@ -129,7 +129,7 @@ void Task::ImportProtosTask::importDirectoryAsync(const QString &dirname) {
     progressUpdateThrottle->setSingleShot(true);
     connect(progressUpdateThrottle, &QTimer::timeout, this, &ImportProtosTask::onThrottledProgress);
 
-    progressDialog = new QProgressDialog("読み込み中...", "キャンセル", 0, 0, qobject_cast<QWidget *>(parent()),
+    progressDialog = new QProgressDialog("ファイルを検索しています...", "キャンセル", 0, 0, qobject_cast<QWidget *>(parent()),
                                          Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::Sheet);
     progressDialog->setWindowModality(Qt::WindowModal);
     connect(progressDialog, &QProgressDialog::canceled, this, &ImportProtosTask::onCanceled);
@@ -153,6 +153,9 @@ void Task::ImportProtosTask::onThrottledProgress() {
         return;
     }
     if (progressDialog != nullptr) {
+        if (progressDialog->maximum() == 0) {
+            progressDialog->setLabelText("インポートしています...");
+        }
         progressDialog->setMaximum(throttledFilesCount);
         progressDialog->setValue(throttledLoaded);
         throttledFilesCount = -1;

--- a/ui/task/ImportProtosTask.cpp
+++ b/ui/task/ImportProtosTask.cpp
@@ -22,8 +22,10 @@ namespace Task {
         }
 
         void interrupt() {
-            QWriteLocker locker(&lock);
-            interrupted = true;
+            if (isInterrupted()) {
+                return;
+            }
+            writeInterrupt();
         }
 
     signals:
@@ -44,6 +46,11 @@ namespace Task {
         bool isInterrupted() {
             QReadLocker locker(&lock);
             return interrupted;
+        }
+
+        void writeInterrupt() {
+            QWriteLocker writeLock(&lock);
+            interrupted = true;
         }
 
         void runInternal() {

--- a/ui/task/ImportProtosTask.cpp
+++ b/ui/task/ImportProtosTask.cpp
@@ -107,8 +107,8 @@ void Task::ImportProtosTask::onProgress(int loaded, int filesCount) {
     throttledLoaded = loaded;
     throttledFilesCount = filesCount;
     if (!progressUpdateThrottle->isActive()) {
-        onThrottledProgress();
         progressUpdateThrottle->start(std::chrono::milliseconds(500));
+        onThrottledProgress();
     }
 }
 

--- a/ui/task/ImportProtosTask.cpp
+++ b/ui/task/ImportProtosTask.cpp
@@ -118,6 +118,7 @@ void Task::ImportProtosTask::importDirectoryAsync(const QString &dirname) {
     connect(worker, &ImportDirectoryWorker::onProgress, this, &ImportProtosTask::onProgress);
     connect(worker, &ImportDirectoryWorker::onLogging, this, &ImportProtosTask::onLogging);
     connect(worker, &ImportDirectoryWorker::finished, this, &ImportProtosTask::finished);
+    connect(worker, &ImportDirectoryWorker::destroyed, this, &ImportProtosTask::onDestroyedWorker);
 
     progressUpdateThrottle = new QTimer(this);
     progressUpdateThrottle->setSingleShot(true);
@@ -166,5 +167,7 @@ void Task::ImportProtosTask::onCanceled() {
         worker->interrupt();
     }
 }
+
+void Task::ImportProtosTask::onDestroyedWorker() { worker = nullptr; }
 
 #include "ImportProtosTask.moc"

--- a/ui/task/ImportProtosTask.cpp
+++ b/ui/task/ImportProtosTask.cpp
@@ -87,7 +87,6 @@ void Task::ImportProtosTask::importDirectoryAsync(const QString &dirname) {
     connect(workerThread, &QThread::finished, worker, &QObject::deleteLater);
     connect(workerThread, &QThread::started, worker, &ImportDirectoryWorker::doWork);
     connect(worker, &ImportDirectoryWorker::loadFinished, this, &ImportProtosTask::loadFinished);
-    connect(worker, &ImportDirectoryWorker::loadFinished, this, &ImportProtosTask::onLoadFinished);
     connect(worker, &ImportDirectoryWorker::onProgress, this, &ImportProtosTask::onProgress);
     connect(worker, &ImportDirectoryWorker::onLogging, this, &ImportProtosTask::onLogging);
 
@@ -98,10 +97,6 @@ void Task::ImportProtosTask::importDirectoryAsync(const QString &dirname) {
 
     progressDialog->show();
     workerThread->start();
-}
-
-void Task::ImportProtosTask::onLoadFinished(const QList<std::shared_ptr<Protocol>> &protocols, bool hasError) {
-    progressDialog->accept();
 }
 
 void Task::ImportProtosTask::onProgress(int loaded, int filesCount) {

--- a/ui/task/ImportProtosTask.cpp
+++ b/ui/task/ImportProtosTask.cpp
@@ -67,7 +67,7 @@ namespace Task {
 
             QList<std::shared_ptr<Protocol>> successes;
             bool error = false;
-            uint64_t done = 0;
+            int done = 0;
             for (const auto &filename : filenames) {
                 if (isInterrupted()) {
                     qDebug() << "ImportDirectoryWorker interrupted!";

--- a/ui/task/ImportProtosTask.cpp
+++ b/ui/task/ImportProtosTask.cpp
@@ -29,11 +29,12 @@ namespace Task {
                 }
                 filenames << iterator.next();
             }
-            emit onProgress(0, filenames.size());
+            emit onProgress(0, 100);
 
             QList<std::shared_ptr<Protocol>> successes;
             bool error = false;
-            int done = 0;
+            uint64_t done = 0;
+            int previousPercentage = 0;
             for (const auto &filename : filenames) {
                 if (QThread::currentThread()->isInterruptionRequested()) {
                     qDebug() << "ImportDirectoryWorker interrupted!";
@@ -60,7 +61,11 @@ namespace Task {
                     error = true;
                 }
 
-                emit onProgress(++done, filenames.size());
+                int percentage = (int)(++done * 100 / filenames.size());
+                if (percentage != previousPercentage) {
+                    emit onProgress(percentage, 100);
+                    previousPercentage = percentage;
+                }
             }
 
             emit loadFinished(successes, error);

--- a/ui/task/ImportProtosTask.cpp
+++ b/ui/task/ImportProtosTask.cpp
@@ -44,6 +44,7 @@ namespace Task {
 
                 if (std::any_of(task.protocols.begin(), task.protocols.end(),
                                 [file](std::shared_ptr<Protocol> &p) { return p->getSource() == file; })) {
+                    emit onProgress(++done, filenames.size());
                     continue;
                 }
 

--- a/ui/task/ImportProtosTask.cpp
+++ b/ui/task/ImportProtosTask.cpp
@@ -1,0 +1,116 @@
+#include "ImportProtosTask.h"
+
+#include <QDebug>
+#include <QDirIterator>
+
+namespace Task {
+    class ImportDirectoryWorker : public QObject {
+        Q_OBJECT
+
+    public:
+        explicit ImportDirectoryWorker(const ImportProtosTask &task, const QString &dirname)
+            : task(task), dirname(dirname) {}
+
+    signals:
+        void loadFinished(const QList<std::shared_ptr<Protocol>> &protocols, bool hasError);
+
+        void onProgress(int loaded, int filesCount);
+
+        void onLogging(const QString &message);
+
+    public slots:
+        void doWork() {
+            QStringList filenames;
+            QDirIterator iterator(dirname, QStringList() << "*.proto", QDir::Files, QDirIterator::Subdirectories);
+            while (iterator.hasNext()) {
+                if (QThread::currentThread()->isInterruptionRequested()) {
+                    qDebug() << "ImportDirectoryWorker interrupted!";
+                    return;
+                }
+                filenames << iterator.next();
+            }
+            emit onProgress(0, filenames.size());
+
+            QList<std::shared_ptr<Protocol>> successes;
+            bool error = false;
+            int done = 0;
+            for (const auto &filename : filenames) {
+                if (QThread::currentThread()->isInterruptionRequested()) {
+                    qDebug() << "ImportDirectoryWorker interrupted!";
+                    return;
+                }
+
+                QFileInfo file(filename);
+
+                if (std::any_of(task.protocols.begin(), task.protocols.end(),
+                                [file](std::shared_ptr<Protocol> &p) { return p->getSource() == file; })) {
+                    continue;
+                }
+
+                try {
+                    const auto protocol = std::make_shared<Protocol>(file, task.imports);
+                    successes.push_back(protocol);
+                } catch (ProtocolLoadException &e) {
+                    emit onLogging(QString("Protoファイルの読込中にエラー: %1").arg(filename));
+
+                    for (const auto &err : *e.errors) {
+                        emit onLogging(QString::fromStdString(err));
+                    }
+
+                    error = true;
+                }
+
+                emit onProgress(++done, filenames.size());
+            }
+
+            emit loadFinished(successes, error);
+        }
+
+    private:
+        const ImportProtosTask &task;
+        const QString dirname;
+    };
+}  // namespace Task
+
+Task::ImportProtosTask::ImportProtosTask(std::vector<std::shared_ptr<Protocol>> &protocols, QStringList &imports,
+                                         QWidget *parent)
+    : QObject(parent), protocols(protocols), imports(imports), workerThread(nullptr), progressDialog(nullptr) {
+    qRegisterMetaType<QList<std::shared_ptr<Protocol>>>();
+}
+
+void Task::ImportProtosTask::importDirectoryAsync(const QString &dirname) {
+    workerThread = new QThread(this);
+    connect(workerThread, &QThread::finished, this, &ImportProtosTask::finished);
+
+    auto worker = new ImportDirectoryWorker(*this, dirname);
+    worker->moveToThread(workerThread);
+    connect(workerThread, &QThread::finished, worker, &QObject::deleteLater);
+    connect(workerThread, &QThread::started, worker, &ImportDirectoryWorker::doWork);
+    connect(worker, &ImportDirectoryWorker::loadFinished, this, &ImportProtosTask::loadFinished);
+    connect(worker, &ImportDirectoryWorker::loadFinished, this, &ImportProtosTask::onLoadFinished);
+    connect(worker, &ImportDirectoryWorker::onProgress, this, &ImportProtosTask::onProgress);
+    connect(worker, &ImportDirectoryWorker::onLogging, this, &ImportProtosTask::onLogging);
+
+    progressDialog = new QProgressDialog("読み込み中...", "キャンセル", 0, 0, qobject_cast<QWidget *>(parent()),
+                                         Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::Sheet);
+    progressDialog->setWindowModality(Qt::WindowModal);
+    connect(progressDialog, &QProgressDialog::canceled, this, &ImportProtosTask::onCanceled);
+
+    progressDialog->show();
+    workerThread->start();
+}
+
+void Task::ImportProtosTask::onLoadFinished(const QList<std::shared_ptr<Protocol>> &protocols, bool hasError) {
+    progressDialog->accept();
+}
+
+void Task::ImportProtosTask::onProgress(int loaded, int filesCount) {
+    if (progressDialog != nullptr) {
+        progressDialog->setMaximum(filesCount);
+        progressDialog->setValue(loaded);
+    }
+}
+
+void Task::ImportProtosTask::onCanceled() { workerThread->requestInterruption(); }
+
+#include "ImportProtosTask.moc"

--- a/ui/task/ImportProtosTask.h
+++ b/ui/task/ImportProtosTask.h
@@ -4,7 +4,6 @@
 #include <QList>
 #include <QObject>
 #include <QProgressDialog>
-#include <QThread>
 #include <QTimer>
 #include <memory>
 

--- a/ui/task/ImportProtosTask.h
+++ b/ui/task/ImportProtosTask.h
@@ -31,8 +31,6 @@ namespace Task {
         void finished();
 
     private slots:
-        void onLoadFinished(const QList<std::shared_ptr<Protocol>> &protocols, bool hasError);
-
         void onProgress(int loaded, int filesCount);
 
         void onCanceled();

--- a/ui/task/ImportProtosTask.h
+++ b/ui/task/ImportProtosTask.h
@@ -38,13 +38,15 @@ namespace Task {
 
         void onThrottledProgress();
 
+        void onLoadFinished(const QList<std::shared_ptr<Protocol>> &protocols, bool hasError);
+
         void onCanceled();
 
     private:
         std::vector<std::shared_ptr<Protocol>> &protocols;
         QStringList &imports;
 
-        QThread *workerThread;
+        ImportDirectoryWorker *worker;
         QProgressDialog *progressDialog;
         QTimer *progressUpdateThrottle;
         int throttledLoaded;

--- a/ui/task/ImportProtosTask.h
+++ b/ui/task/ImportProtosTask.h
@@ -22,6 +22,8 @@ namespace Task {
         ImportProtosTask(std::vector<std::shared_ptr<Protocol>> &protocols, QStringList &imports,
                          QWidget *parent = nullptr);
 
+        ~ImportProtosTask() override;
+
         void importDirectoryAsync(const QString &dirname);
 
     signals:

--- a/ui/task/ImportProtosTask.h
+++ b/ui/task/ImportProtosTask.h
@@ -5,6 +5,7 @@
 #include <QObject>
 #include <QProgressDialog>
 #include <QThread>
+#include <QTimer>
 #include <memory>
 
 #include "entity/Protocol.h"
@@ -33,6 +34,8 @@ namespace Task {
     private slots:
         void onProgress(int loaded, int filesCount);
 
+        void onThrottledProgress();
+
         void onCanceled();
 
     private:
@@ -41,6 +44,9 @@ namespace Task {
 
         QThread *workerThread;
         QProgressDialog *progressDialog;
+        QTimer *progressUpdateThrottle;
+        int throttledLoaded;
+        int throttledFilesCount;
 
         friend ImportDirectoryWorker;
     };

--- a/ui/task/ImportProtosTask.h
+++ b/ui/task/ImportProtosTask.h
@@ -41,7 +41,7 @@ namespace Task {
 
         void onCanceled();
 
-        void onDestroyedWorker();
+        void onFinished();
 
     private:
         std::vector<std::shared_ptr<Protocol>> &protocols;
@@ -52,6 +52,7 @@ namespace Task {
         QTimer *progressUpdateThrottle;
         int throttledLoaded;
         int throttledFilesCount;
+        bool alreadyFinished;
 
         friend ImportDirectoryWorker;
     };

--- a/ui/task/ImportProtosTask.h
+++ b/ui/task/ImportProtosTask.h
@@ -1,0 +1,53 @@
+#ifndef FLORARPC_IMPORTPROTOSTASK_H
+#define FLORARPC_IMPORTPROTOSTASK_H
+
+#include <QList>
+#include <QObject>
+#include <QProgressDialog>
+#include <QThread>
+#include <memory>
+
+#include "entity/Protocol.h"
+
+namespace Task {
+    class ImportDirectoryWorker;
+
+    class ImportProtosTask : public QObject {
+        Q_OBJECT
+
+        Q_DISABLE_COPY(ImportProtosTask)
+
+    public:
+        ImportProtosTask(std::vector<std::shared_ptr<Protocol>> &protocols, QStringList &imports,
+                         QWidget *parent = nullptr);
+
+        void importDirectoryAsync(const QString &dirname);
+
+    signals:
+        void loadFinished(const QList<std::shared_ptr<Protocol>> &protocols, bool hasError);
+
+        void onLogging(const QString &message);
+
+        void finished();
+
+    private slots:
+        void onLoadFinished(const QList<std::shared_ptr<Protocol>> &protocols, bool hasError);
+
+        void onProgress(int loaded, int filesCount);
+
+        void onCanceled();
+
+    private:
+        std::vector<std::shared_ptr<Protocol>> &protocols;
+        QStringList &imports;
+
+        QThread *workerThread;
+        QProgressDialog *progressDialog;
+
+        friend ImportDirectoryWorker;
+    };
+}  // namespace Task
+
+Q_DECLARE_METATYPE(QList<std::shared_ptr<Protocol>>)
+
+#endif  // FLORARPC_IMPORTPROTOSTASK_H

--- a/ui/task/ImportProtosTask.h
+++ b/ui/task/ImportProtosTask.h
@@ -41,6 +41,8 @@ namespace Task {
 
         void onCanceled();
 
+        void onDestroyedWorker();
+
     private:
         std::vector<std::shared_ptr<Protocol>> &protocols;
         QStringList &imports;


### PR DESCRIPTION
Protoファイルを1つずつインポートするのではなく、フォルダを選択してその中のProtoファイルを全てインポートする機能。  
WindowsやmacOSだとまあまあ遅いのでキャンセル可能な仕様にした結果、コードが大変なことになった。

![Screenshot_20200930_022517](https://user-images.githubusercontent.com/1352154/94593311-33c00580-02c4-11eb-978d-2c5279979e84.png)

![image](https://user-images.githubusercontent.com/1352154/94593800-52be9780-02c4-11eb-8ab5-2589ed62ccb5.png)
