### PR TITLE
セッション所要秒数(通信時間)の表示

### DIFF
--- a/entity/Session.h
+++ b/entity/Session.h
@@ -1,14 +1,17 @@
 #ifndef FLORARPC_SESSION_H
 #define FLORARPC_SESSION_H
 
-#include <QObject>
-#include <QMultiMap>
-#include <QThread>
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>
 #include <grpcpp/completion_queue.h>
 #include <grpcpp/generic/generic_stub_impl.h>
 #include <grpcpp/security/credentials.h>
+
+#include <QMultiMap>
+#include <QObject>
+#include <QThread>
+#include <chrono>
+
 #include "Method.h"
 
 class Session : public QObject {
@@ -23,6 +26,8 @@ public:
             const Metadata &metadata, QObject *parent = nullptr);
 
     ~Session() override;
+
+    std::chrono::steady_clock::time_point &getBeginTime();
 
 signals:
 
@@ -85,6 +90,7 @@ private:
     std::shared_ptr<grpc::Channel> channel;
     std::unique_ptr<grpc::GenericClientAsyncReaderWriter> call;
     QThread queueWatcherWorker;
+    std::chrono::steady_clock::time_point beginTime;
 
     Sequence sequence = Sequence::Preparing;
     bool receivedInitialMetadata = false;

--- a/ui/Editor.cpp
+++ b/ui/Editor.cpp
@@ -350,6 +350,12 @@ void Editor::onSessionFinished(int code, const QString &message, const QByteArra
     if (code != grpc::StatusCode::OK) {
         setErrorToResponseView(GrpcUtility::errorCodeToString((grpc::StatusCode)code), message, details);
     }
+
+    const auto elapsed = std::chrono::steady_clock::now() - session->getBeginTime();
+    const auto secs = std::chrono::duration_cast<std::chrono::seconds>(elapsed).count();
+    const auto nsecs = std::chrono::duration_cast<std::chrono::nanoseconds>(elapsed).count() % 1000000;
+    ui.responseElapsedLabel->setText(QString("%1.%2s").arg(secs).arg(nsecs));
+
     cleanupSession();
 }
 
@@ -388,6 +394,7 @@ void Editor::addMetadataRow(const QString &key, const QString &value) {
 }
 
 void Editor::clearResponseView() {
+    ui.responseElapsedLabel->clear();
     ui.responseEdit->clear();
     ui.responseMetadataTable->clearContents();
     ui.responseMetadataTable->setRowCount(0);

--- a/ui/Editor.ui
+++ b/ui/Editor.ui
@@ -213,11 +213,31 @@
         <number>0</number>
        </property>
        <item>
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>Response</string>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <property name="bottomMargin">
+          <number>0</number>
          </property>
-        </widget>
+         <item>
+          <widget class="QLabel" name="label">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Response</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="responseElapsedLabel">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item>
         <widget class="QTabWidget" name="responseTabs">


### PR DESCRIPTION
リクエスト送信開始〜通信切断までの時間を表示する。std::chrono::steady_clockを使ってるので突然NTPが発狂してもたぶんいい感じになる。

![image](https://user-images.githubusercontent.com/1352154/94993347-4b043900-05cb-11eb-850a-810bf2df6a54.png)
