### PR TITLE
grpc-status-details-bin内のstringをUTF-8文字列として出力

### DIFF
--- a/ui/Editor.cpp
+++ b/ui/Editor.cpp
@@ -363,6 +363,7 @@ void Editor::onSessionFinished(int code, const QString &message, const QByteArra
                 // TODO: JSONにしたい気持ちはあるけど、Anyの解決に失敗した時に何も出力されないのが困るから妥協した
                 google::protobuf::TextFormat::Printer printer;
                 printer.SetExpandAny(true);
+                printer.SetUseUtf8StringEscaping(true);
                 bool successPrint = printer.PrintToString(*status, &out);
                 if (successPrint) {
                     formattedDetails = QString::fromStdString(out);


### PR DESCRIPTION
google.rpc.Status内で日本語を使いたいことがあって、エスケープで読めなくて困ったので出力設定を変更する。