### PR TITLE
libgrpc++の_impl系ヘッダーを参照しないようにする

### DIFF
--- a/entity/Session.cpp
+++ b/entity/Session.cpp
@@ -36,10 +36,10 @@ public slots:
         void *gotTag;
         bool ok;
         while (auto event = session.queue.AsyncNext(&gotTag, &ok, system_clock::now())) {
-            if (event == grpc_impl::CompletionQueue::SHUTDOWN) {
+            if (event == grpc::CompletionQueue::SHUTDOWN) {
                 break;
             }
-            if (event == grpc_impl::CompletionQueue::TIMEOUT) {
+            if (event == grpc::CompletionQueue::TIMEOUT) {
                 if (QThread::currentThread()->isInterruptionRequested()) {
                     break;
                 }

--- a/entity/Session.h
+++ b/entity/Session.h
@@ -4,7 +4,7 @@
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>
 #include <grpcpp/completion_queue.h>
-#include <grpcpp/generic/generic_stub_impl.h>
+#include <grpcpp/generic/generic_stub.h>
 #include <grpcpp/security/credentials.h>
 
 #include <QMultiMap>


### PR DESCRIPTION
Arch Linuxでビルドが通らなくなっていたので、そもそも参照すべきではないのだろうと思いながら修正。