### PR TITLE
ワークスペースツリーをメソッド名でフィルタ

### DIFF
--- a/ui/MainWindow.h
+++ b/ui/MainWindow.h
@@ -3,6 +3,7 @@
 
 #include <QMainWindow>
 #include <QShortcut>
+#include <QSortFilterProxyModel>
 #include <QTimer>
 
 #include "../entity/Certificate.h"
@@ -69,6 +70,7 @@ private:
     std::vector<std::shared_ptr<Server>> servers;
     std::vector<std::shared_ptr<Certificate>> certificates;
     std::unique_ptr<ProtocolTreeModel> protocolTreeModel;
+    QSortFilterProxyModel proxyModel;
     QStringList imports;
     QShortcut tabCloseShortcut;
     QMenu treeFileContextMenu;

--- a/ui/MainWindow.ui
+++ b/ui/MainWindow.ui
@@ -115,7 +115,7 @@
    <property name="minimumSize">
     <size>
      <width>123</width>
-     <height>123</height>
+     <height>159</height>
     </size>
    </property>
    <property name="features">
@@ -133,7 +133,7 @@
    <widget class="QWidget" name="dockWidgetContents">
     <layout class="QVBoxLayout" name="verticalLayout_8">
      <property name="spacing">
-      <number>6</number>
+      <number>0</number>
      </property>
      <property name="leftMargin">
       <number>0</number>
@@ -147,6 +147,16 @@
      <property name="bottomMargin">
       <number>0</number>
      </property>
+     <item>
+      <widget class="QLineEdit" name="treeFilterEdit">
+       <property name="placeholderText">
+        <string>フィルタ</string>
+       </property>
+       <property name="clearButtonEnabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
      <item>
       <widget class="QTreeView" name="treeView">
        <property name="sizePolicy">

--- a/ui/ProtocolTreeModel.cpp
+++ b/ui/ProtocolTreeModel.cpp
@@ -146,6 +146,12 @@ QVariant ProtocolTreeModel::data(const QModelIndex &index, int role) const {
                 }
             }
             break;
+        case Qt::UserRole:  // use to filter
+            if (node->type == Node::MethodNode) {
+                return QString::fromStdString(node->getMethodDescriptor()->name());
+            } else {
+                return QVariant();
+            }
         default:
             return QVariant();
     }


### PR DESCRIPTION
ワークスペースツリーの上にフィルタ用のテキストボックスを追加します。  
RPCメソッド名で表示を絞りこめるようになります。

サービス名を含めた完全修飾名でフィルタできても良いかもしれない。

![Screenshot_20201114_143006](https://user-images.githubusercontent.com/1352154/99140508-ec2fe600-2685-11eb-8cba-fe276191cd8c.png)
![Screenshot_20201114_143012](https://user-images.githubusercontent.com/1352154/99140509-efc36d00-2685-11eb-86ab-b028183d49cb.png)
