### PR TITLE
Fix/session buffer memory leak

### DIFF
--- a/entity/Session.cpp
+++ b/entity/Session.cpp
@@ -181,7 +181,6 @@ Session::Sequence Session::getSequence() { return sequence; }
 void Session::send(const grpc::ByteBuffer &buffer) {
     qDebug() << __FUNCTION__;
     writeBuffer = buffer;
-    writeBuffer.Duplicate();
     if (sequence == Sequence::Preparing) {
         call->StartCall(writeTag());
     } else {

--- a/entity/Session.cpp
+++ b/entity/Session.cpp
@@ -112,7 +112,6 @@ private:
         }
 
         grpc::ByteBuffer buffer(session.readBuffer);
-        buffer.Duplicate();
         emit messageReceived(buffer);
 
         session.readTag.advance();


### PR DESCRIPTION
送受信それぞれのgrpc::ByteBufferが余計な操作によってメモリリークしていた。

grpc::ByteBuffer::Duplicate() 相当の処理はコピーコンストラクタおよび代入演算子で実行されるので、手動で実行する必要は無い。  
この呼び出しによって、内部に保持しているgrpc_byte_bufferの参照カウントが増えてしまい、デストラクト時に解放されなくなっていた。