### PR TITLE
Streaming RPCで常に新着を表示するオプションの追加

### DIFF
--- a/ui/Editor.cpp
+++ b/ui/Editor.cpp
@@ -107,8 +107,10 @@ Editor::Editor(std::unique_ptr<Method> &&method, QWidget *parent)
     if (this->method->isServerStreaming()) {
         ui.responseBodyPager->show();
         ui.responseBodyPager->setDisabled(true);
+        ui.followResponseCheck->show();
     } else {
         ui.responseBodyPager->hide();
+        ui.followResponseCheck->hide();
     }
 
     updateSendButton();
@@ -335,6 +337,13 @@ void Editor::onMessageReceived(const grpc::ByteBuffer &buffer) {
     }
 
     updateResponsePager();
+
+    if (method->isServerStreaming() && ui.followResponseCheck->isChecked()) {
+        auto current = ui.responseBodyPageSpin->value();
+        if (current == responses.size() - 1) {
+            ui.responseBodyPageSpin->setValue(responses.size());
+        }
+    }
 
     if (!(method->isClientStreaming() || method->isServerStreaming())) {
         emit session->finish();

--- a/ui/Editor.cpp
+++ b/ui/Editor.cpp
@@ -107,10 +107,8 @@ Editor::Editor(std::unique_ptr<Method> &&method, QWidget *parent)
     if (this->method->isServerStreaming()) {
         ui.responseBodyPager->show();
         ui.responseBodyPager->setDisabled(true);
-        ui.followResponseCheck->show();
     } else {
         ui.responseBodyPager->hide();
-        ui.followResponseCheck->hide();
     }
 
     updateSendButton();

--- a/ui/Editor.ui
+++ b/ui/Editor.ui
@@ -327,6 +327,16 @@
                 </property>
                </spacer>
               </item>
+              <item>
+               <widget class="QCheckBox" name="followResponseCheck">
+                <property name="text">
+                 <string>常に新着を表示</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
              </layout>
             </widget>
            </item>


### PR DESCRIPTION
「常に新着を表示する」チェックボックスを追加。これはServer-side RPCかBidirectional RPCの場合のみ表示される。  
これにチェックを付けていると、レスポンスの最終ページを表示している間は自動的に新着レスポンスが表示され続けるようになる。

![Screenshot_20210417_192412](https://user-images.githubusercontent.com/1352154/115109730-7fad7000-9fb2-11eb-86a3-a202b3aa8ee5.png)
