### PR TITLE
Streaming Responseの最終ページに移動するボタン

### DIFF
--- a/ui/Editor.cpp
+++ b/ui/Editor.cpp
@@ -52,6 +52,7 @@ Editor::Editor(std::unique_ptr<Method> &&method, QWidget *parent)
             &Editor::onResponseBodyPageChanged);
     connect(ui.prevResponseBodyButton, &QPushButton::clicked, this, &Editor::onPrevResponseBodyButtonClicked);
     connect(ui.nextResponseBodyButton, &QPushButton::clicked, this, &Editor::onNextResponseBodyButtonClicked);
+    connect(ui.lastResponseBodyButton, &QPushButton::clicked, this, &Editor::onLastResponseBodyButtonClicked);
     connect(ui.serverSelectBox, qOverload<int>(&QComboBox::currentIndexChanged), this,
             &Editor::willEmitWorkspaceModified);
     connect(ui.requestEdit, &QTextEdit::textChanged, this, &Editor::willEmitWorkspaceModified);
@@ -319,6 +320,11 @@ void Editor::onNextResponseBodyButtonClicked() {
     updateResponsePager();
 }
 
+void Editor::onLastResponseBodyButtonClicked() {
+    ui.responseBodyPageSpin->setValue(responses.size());
+    updateResponsePager();
+}
+
 void Editor::onMessageSent() {
     sendingRequest = false;
     updateSendButton();
@@ -478,9 +484,11 @@ void Editor::updateResponsePager() {
     if (responses.isEmpty()) {
         ui.prevResponseBodyButton->setDisabled(true);
         ui.nextResponseBodyButton->setDisabled(true);
+        ui.lastResponseBodyButton->setDisabled(true);
     } else {
         ui.prevResponseBodyButton->setDisabled(false);
         ui.nextResponseBodyButton->setDisabled(false);
+        ui.lastResponseBodyButton->setDisabled(false);
     }
 
     if (ui.responseBodyPageSpin->value() <= 1) {
@@ -488,6 +496,7 @@ void Editor::updateResponsePager() {
     }
     if (ui.responseBodyPageSpin->value() == responses.size()) {
         ui.nextResponseBodyButton->setDisabled(true);
+        ui.lastResponseBodyButton->setDisabled(true);
     }
 }
 

--- a/ui/Editor.cpp
+++ b/ui/Editor.cpp
@@ -106,10 +106,10 @@ Editor::Editor(std::unique_ptr<Method> &&method, QWidget *parent)
     }
 
     if (this->method->isServerStreaming()) {
-        ui.responseBodyPager->show();
+        ui.responseBodyPagerWrapper->show();
         ui.responseBodyPager->setDisabled(true);
     } else {
-        ui.responseBodyPager->hide();
+        ui.responseBodyPagerWrapper->hide();
     }
 
     updateSendButton();

--- a/ui/Editor.h
+++ b/ui/Editor.h
@@ -52,6 +52,8 @@ private slots:
 
     void onNextResponseBodyButtonClicked();
 
+    void onLastResponseBodyButtonClicked();
+
     void onMessageSent();
 
     void onMetadataReceived(const Session::Metadata &metadata);

--- a/ui/Editor.ui
+++ b/ui/Editor.ui
@@ -245,7 +245,7 @@
           </attribute>
           <layout class="QVBoxLayout" name="verticalLayout_2">
            <item>
-            <widget class="QWidget" name="responseBodyPager" native="true">
+            <widget class="QWidget" name="responseBodyPagerWrapper" native="true">
              <layout class="QVBoxLayout" name="verticalLayout_3">
               <property name="leftMargin">
                <number>0</number>
@@ -260,7 +260,7 @@
                <number>0</number>
               </property>
               <item>
-               <widget class="QWidget" name="horizontalWidget" native="true">
+               <widget class="QWidget" name="responseBodyPager" native="true">
                 <property name="minimumSize">
                  <size>
                   <width>0</width>

--- a/ui/Editor.ui
+++ b/ui/Editor.ui
@@ -246,7 +246,7 @@
           <layout class="QVBoxLayout" name="verticalLayout_2">
            <item>
             <widget class="QWidget" name="responseBodyPager" native="true">
-             <layout class="QHBoxLayout" name="horizontalLayout_2">
+             <layout class="QVBoxLayout" name="verticalLayout_3">
               <property name="leftMargin">
                <number>0</number>
               </property>
@@ -260,72 +260,106 @@
                <number>0</number>
               </property>
               <item>
-               <widget class="QPushButton" name="prevResponseBodyButton">
-                <property name="text">
-                 <string>Prev</string>
-                </property>
-                <property name="icon">
-                 <iconset theme="go-previous">
-                  <normaloff>.</normaloff>.</iconset>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QPushButton" name="nextResponseBodyButton">
-                <property name="text">
-                 <string>Next</string>
-                </property>
-                <property name="icon">
-                 <iconset theme="go-next">
-                  <normaloff>.</normaloff>.</iconset>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QSpinBox" name="responseBodyPageSpin">
+               <widget class="QWidget" name="horizontalWidget" native="true">
                 <property name="minimumSize">
                  <size>
-                  <width>100</width>
-                  <height>0</height>
+                  <width>0</width>
+                  <height>12</height>
                  </size>
                 </property>
-                <property name="buttonSymbols">
-                 <enum>QAbstractSpinBox::NoButtons</enum>
-                </property>
-                <property name="minimum">
-                 <number>1</number>
-                </property>
-                <property name="maximum">
-                 <number>1</number>
-                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_2">
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <widget class="QPushButton" name="prevResponseBodyButton">
+                   <property name="text">
+                    <string>Prev</string>
+                   </property>
+                   <property name="icon">
+                    <iconset theme="go-previous">
+                     <normaloff>.</normaloff>.</iconset>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="nextResponseBodyButton">
+                   <property name="text">
+                    <string>Next</string>
+                   </property>
+                   <property name="icon">
+                    <iconset theme="go-next">
+                     <normaloff>.</normaloff>.</iconset>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="lastResponseBodyButton">
+                   <property name="text">
+                    <string>Last</string>
+                   </property>
+                   <property name="icon">
+                    <iconset theme="go-last"/>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QSpinBox" name="responseBodyPageSpin">
+                   <property name="minimumSize">
+                    <size>
+                     <width>100</width>
+                     <height>0</height>
+                    </size>
+                   </property>
+                   <property name="buttonSymbols">
+                    <enum>QAbstractSpinBox::NoButtons</enum>
+                   </property>
+                   <property name="minimum">
+                    <number>1</number>
+                   </property>
+                   <property name="maximum">
+                    <number>1</number>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="label_5">
+                   <property name="text">
+                    <string>/</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="responseBodyMaxPageLabel">
+                   <property name="text">
+                    <string>1</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
                </widget>
-              </item>
-              <item>
-               <widget class="QLabel" name="label_5">
-                <property name="text">
-                 <string>/</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QLabel" name="responseBodyMaxPageLabel">
-                <property name="text">
-                 <string>1</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <spacer name="horizontalSpacer">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
               </item>
               <item>
                <widget class="QCheckBox" name="followResponseCheck">


### PR DESCRIPTION
Next ボタンの隣に、最終ページまでジャンプするボタンを追加する。  
新着表示オプションの仕様との兼ね合いで、このボタンがあったほうが使いやすい。

ついでに、新着表示チェックボックスはストリーミングの開始前から操作できるよう修正した。ここが操作できなかったのは意図しないものだった。

![Screenshot_20210417_202715](https://user-images.githubusercontent.com/1352154/115111432-4e856d80-9fbb-11eb-84de-4e3f691d6557.png)
