### PR TITLE
SetSslTargetNameOverride() のサポート

### DIFF
--- a/entity/Certificate.cpp
+++ b/entity/Certificate.cpp
@@ -26,7 +26,8 @@ Certificate::Certificate(const florarpc::Certificate &certificate)
       privateKeyPath(QString::fromStdString(certificate.private_key_path())),
       privateKeyName(QString::fromStdString(certificate.private_key_name())),
       certChainPath(QString::fromStdString(certificate.cert_chain_path())),
-      certChainName(QString::fromStdString(certificate.cert_chain_name())) {}
+      certChainName(QString::fromStdString(certificate.cert_chain_name())),
+      targetNameOverride(QString::fromStdString(certificate.target_name_override())) {}
 
 void Certificate::writeCertificate(florarpc::Certificate &certificate) {
     certificate.set_id(id.toString().toStdString());
@@ -37,6 +38,7 @@ void Certificate::writeCertificate(florarpc::Certificate &certificate) {
     certificate.set_private_key_name(privateKeyName.toStdString());
     certificate.set_cert_chain_path(certChainPath.toStdString());
     certificate.set_cert_chain_name(certChainName.toStdString());
+    certificate.set_target_name_override(targetNameOverride.toStdString());
 
 #ifdef __clang__
 #pragma clang diagnostic push

--- a/entity/Certificate.h
+++ b/entity/Certificate.h
@@ -26,6 +26,7 @@ public:
     QString privateKeyName;
     QString certChainPath;
     QString certChainName;
+    QString targetNameOverride;
 };
 
 #endif  // FLORARPC_CERTIFICATE_H

--- a/entity/Session.cpp
+++ b/entity/Session.cpp
@@ -142,7 +142,7 @@ private:
 };
 
 Session::Session(const Method &method, const QString &serverAddress, std::shared_ptr<grpc::ChannelCredentials> &creds,
-                 const Metadata &metadata, QObject *parent)
+                 const grpc::ChannelArguments &channelArguments, const Metadata &metadata, QObject *parent)
     : QObject(parent),
       method(method),
       beginTime(std::chrono::steady_clock::now()),
@@ -155,7 +155,7 @@ Session::Session(const Method &method, const QString &serverAddress, std::shared
         context.AddMetadata(iter.key().toStdString(), iter.value().toStdString());
     }
 
-    channel = grpc::CreateChannel(serverAddress.toStdString(), creds);
+    channel = grpc::CreateCustomChannel(serverAddress.toStdString(), creds, channelArguments);
     grpc::GenericStub stub(channel);
     call = stub.PrepareCall(&context, method.getRequestPath(), &queue);
 

--- a/entity/Session.h
+++ b/entity/Session.h
@@ -30,7 +30,7 @@ public:
     };
 
     Session(const Method &method, const QString &serverAddress, std::shared_ptr<grpc::ChannelCredentials> &creds,
-            const Metadata &metadata, QObject *parent = nullptr);
+            const grpc::ChannelArguments &channelArguments, const Metadata &metadata, QObject *parent = nullptr);
 
     ~Session() override;
 

--- a/proto/florarpc/workspace.proto
+++ b/proto/florarpc/workspace.proto
@@ -54,6 +54,7 @@ message Certificate {
   string private_key_name = 6;
   string cert_chain_path = 11;
   string cert_chain_name = 8;
+  string target_name_override = 12;
 
   // deprecated fields
   bytes root_certs = 3 [deprecated = true];

--- a/ui/CertsEditDialog.cpp
+++ b/ui/CertsEditDialog.cpp
@@ -11,6 +11,8 @@ CertsEditDialog::CertsEditDialog(std::shared_ptr<Certificate> certificate, QWidg
             &CertsEditDialog::onOkButtonClick);
     connect(ui.buttonBox->button(QDialogButtonBox::Cancel), &QAbstractButton::clicked, this,
             &CertsEditDialog::onCancelButtonClick);
+    connect(ui.targetNameOverrideCheck, &QCheckBox::stateChanged, this,
+            &CertsEditDialog::onTargetNameOverrideCheckChanged);
 
     ui.rootCertsControl->setAcceptType(CertsEditControl::AcceptType::Certificate);
     ui.privateKeyControl->setAcceptType(CertsEditControl::AcceptType::RSAPrivateKey);
@@ -23,6 +25,10 @@ CertsEditDialog::CertsEditDialog(std::shared_ptr<Certificate> certificate, QWidg
     ui.privateKeyControl->setFilename(this->certificate->privateKeyName);
     ui.certChainControl->setFilePath(this->certificate->certChainPath);
     ui.certChainControl->setFilename(this->certificate->certChainName);
+    if (!this->certificate->targetNameOverride.isEmpty()) {
+        ui.targetNameOverrideCheck->setChecked(true);
+        ui.targetNameOverrideEdit->setText(this->certificate->targetNameOverride);
+    }
 }
 
 void CertsEditDialog::onOkButtonClick() {
@@ -43,8 +49,17 @@ void CertsEditDialog::onOkButtonClick() {
     certificate->privateKeyName = ui.privateKeyControl->getFilename();
     certificate->certChainPath = ui.certChainControl->getFilePath();
     certificate->certChainName = ui.certChainControl->getFilename();
+    if (ui.targetNameOverrideCheck->isChecked()) {
+        certificate->targetNameOverride = ui.targetNameOverrideEdit->text();
+    } else {
+        certificate->targetNameOverride = "";
+    }
 
     done(Accepted);
 }
 
 void CertsEditDialog::onCancelButtonClick() { done(Rejected); }
+
+void CertsEditDialog::onTargetNameOverrideCheckChanged(int state) {
+    ui.targetNameOverrideEdit->setEnabled(state == Qt::CheckState::Checked);
+}

--- a/ui/CertsEditDialog.h
+++ b/ui/CertsEditDialog.h
@@ -17,6 +17,8 @@ private slots:
 
     void onCancelButtonClick();
 
+    void onTargetNameOverrideCheckChanged(int state);
+
 private:
     Ui_CertsEditDialog ui;
     std::shared_ptr<Certificate> certificate;

--- a/ui/CertsEditDialog.ui
+++ b/ui/CertsEditDialog.ui
@@ -62,6 +62,37 @@
      <item row="3" column="1">
       <widget class="CertsEditControl" name="privateKeyControl" native="true"/>
      </item>
+     <item row="4" column="1">
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QCheckBox" name="targetNameOverrideCheck">
+         <property name="text">
+          <string>ホスト名検証を別名で偽装</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_5">
+         <property name="font">
+          <font>
+           <pointsize>9</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>接続先アドレスと証明書のCNが異なり、接続に失敗する場合に使います。
+ここに設定したホスト名を使って、TLSの検証を通過させることができます。</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="targetNameOverrideEdit">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
     </layout>
    </item>
    <item>

--- a/ui/CertsEditDialog.ui
+++ b/ui/CertsEditDialog.ui
@@ -75,7 +75,7 @@
         <widget class="QLabel" name="label_5">
          <property name="font">
           <font>
-           <pointsize>9</pointsize>
+           <pointsize>8</pointsize>
           </font>
          </property>
          <property name="text">


### PR DESCRIPTION
デバッグのためにTLSのホスト名検証をスキップしたいケースが時々あるので、それができるようにした。  
本来であれば単に検証をスキップするというチェックボックスを付けるだけにしたかったが、libgrpc++のAPI的にそれが出来なさそうだったので、手入力でホスト名をオーバーライドする形にした。

![Screenshot_20211008_001630](https://user-images.githubusercontent.com/1352154/136413818-7e0efb61-584f-4704-8d12-804a3dbaca78.png)
