### PR TITLE
TargetNameOverrideの設定を証明書単位ではなく、サーバー単位で行えるようにする

### DIFF
--- a/entity/Certificate.cpp
+++ b/entity/Certificate.cpp
@@ -26,8 +26,7 @@ Certificate::Certificate(const florarpc::Certificate &certificate)
       privateKeyPath(QString::fromStdString(certificate.private_key_path())),
       privateKeyName(QString::fromStdString(certificate.private_key_name())),
       certChainPath(QString::fromStdString(certificate.cert_chain_path())),
-      certChainName(QString::fromStdString(certificate.cert_chain_name())),
-      targetNameOverride(QString::fromStdString(certificate.target_name_override())) {}
+      certChainName(QString::fromStdString(certificate.cert_chain_name())) {}
 
 void Certificate::writeCertificate(florarpc::Certificate &certificate) {
     certificate.set_id(id.toString().toStdString());
@@ -38,7 +37,6 @@ void Certificate::writeCertificate(florarpc::Certificate &certificate) {
     certificate.set_private_key_name(privateKeyName.toStdString());
     certificate.set_cert_chain_path(certChainPath.toStdString());
     certificate.set_cert_chain_name(certChainName.toStdString());
-    certificate.set_target_name_override(targetNameOverride.toStdString());
 
 #ifdef __clang__
 #pragma clang diagnostic push

--- a/entity/Certificate.h
+++ b/entity/Certificate.h
@@ -26,7 +26,6 @@ public:
     QString privateKeyName;
     QString certChainPath;
     QString certChainName;
-    QString targetNameOverride;
 };
 
 #endif  // FLORARPC_CERTIFICATE_H

--- a/entity/Server.cpp
+++ b/entity/Server.cpp
@@ -10,7 +10,8 @@ Server::Server(const florarpc::Server& server)
       address(QString::fromStdString(server.address())),
       useTLS(server.usetls()),
       certificateUUID(QByteArray::fromStdString(server.certificate_id())),
-      sharedMetadata(QString::fromStdString(server.shared_metadata())) {}
+      sharedMetadata(QString::fromStdString(server.shared_metadata())),
+      tlsTargetNameOverride(QString::fromStdString(server.tls_target_name_override())) {}
 
 void Server::writeServer(florarpc::Server& server) {
     server.set_id(id.toString().toStdString());
@@ -19,6 +20,7 @@ void Server::writeServer(florarpc::Server& server) {
     server.set_usetls(useTLS);
     server.set_certificate_id(certificateUUID.toString().toStdString());
     server.set_shared_metadata(sharedMetadata.toStdString());
+    server.set_tls_target_name_override(tlsTargetNameOverride.toStdString());
 }
 
 std::shared_ptr<Certificate> Server::findCertificate(const std::vector<std::shared_ptr<Certificate>>& certificates) {

--- a/entity/Server.h
+++ b/entity/Server.h
@@ -23,6 +23,7 @@ public:
     bool useTLS;
     QUuid certificateUUID;
     QString sharedMetadata;
+    QString tlsTargetNameOverride;
 };
 
 #endif  // FLORARPC_SERVER_H

--- a/proto/florarpc/workspace.proto
+++ b/proto/florarpc/workspace.proto
@@ -43,6 +43,7 @@ message Server {
   bool useTLS = 4;
   string certificate_id = 5;
   string shared_metadata = 6;
+  string tls_target_name_override = 7;
 }
 
 message Certificate {
@@ -54,10 +55,10 @@ message Certificate {
   string private_key_name = 6;
   string cert_chain_path = 11;
   string cert_chain_name = 8;
-  string target_name_override = 12;
 
   // deprecated fields
   bytes root_certs = 3 [deprecated = true];
   bytes private_key = 5 [deprecated = true];
   bytes cert_chain = 7 [deprecated = true];
+  string target_name_override = 12 [deprecated = true];
 }

--- a/ui/CertsEditDialog.cpp
+++ b/ui/CertsEditDialog.cpp
@@ -11,8 +11,6 @@ CertsEditDialog::CertsEditDialog(std::shared_ptr<Certificate> certificate, QWidg
             &CertsEditDialog::onOkButtonClick);
     connect(ui.buttonBox->button(QDialogButtonBox::Cancel), &QAbstractButton::clicked, this,
             &CertsEditDialog::onCancelButtonClick);
-    connect(ui.targetNameOverrideCheck, &QCheckBox::stateChanged, this,
-            &CertsEditDialog::onTargetNameOverrideCheckChanged);
 
     ui.rootCertsControl->setAcceptType(CertsEditControl::AcceptType::Certificate);
     ui.privateKeyControl->setAcceptType(CertsEditControl::AcceptType::RSAPrivateKey);
@@ -25,10 +23,6 @@ CertsEditDialog::CertsEditDialog(std::shared_ptr<Certificate> certificate, QWidg
     ui.privateKeyControl->setFilename(this->certificate->privateKeyName);
     ui.certChainControl->setFilePath(this->certificate->certChainPath);
     ui.certChainControl->setFilename(this->certificate->certChainName);
-    if (!this->certificate->targetNameOverride.isEmpty()) {
-        ui.targetNameOverrideCheck->setChecked(true);
-        ui.targetNameOverrideEdit->setText(this->certificate->targetNameOverride);
-    }
 }
 
 void CertsEditDialog::onOkButtonClick() {
@@ -49,17 +43,8 @@ void CertsEditDialog::onOkButtonClick() {
     certificate->privateKeyName = ui.privateKeyControl->getFilename();
     certificate->certChainPath = ui.certChainControl->getFilePath();
     certificate->certChainName = ui.certChainControl->getFilename();
-    if (ui.targetNameOverrideCheck->isChecked()) {
-        certificate->targetNameOverride = ui.targetNameOverrideEdit->text();
-    } else {
-        certificate->targetNameOverride = "";
-    }
 
     done(Accepted);
 }
 
 void CertsEditDialog::onCancelButtonClick() { done(Rejected); }
-
-void CertsEditDialog::onTargetNameOverrideCheckChanged(int state) {
-    ui.targetNameOverrideEdit->setEnabled(state == Qt::CheckState::Checked);
-}

--- a/ui/CertsEditDialog.h
+++ b/ui/CertsEditDialog.h
@@ -17,8 +17,6 @@ private slots:
 
     void onCancelButtonClick();
 
-    void onTargetNameOverrideCheckChanged(int state);
-
 private:
     Ui_CertsEditDialog ui;
     std::shared_ptr<Certificate> certificate;

--- a/ui/CertsEditDialog.ui
+++ b/ui/CertsEditDialog.ui
@@ -62,37 +62,6 @@
      <item row="3" column="1">
       <widget class="CertsEditControl" name="privateKeyControl" native="true"/>
      </item>
-     <item row="4" column="1">
-      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <item>
-        <widget class="QCheckBox" name="targetNameOverrideCheck">
-         <property name="text">
-          <string>ホスト名検証を別名で偽装</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_5">
-         <property name="font">
-          <font>
-           <pointsize>8</pointsize>
-          </font>
-         </property>
-         <property name="text">
-          <string>接続先アドレスと証明書のCNが異なり、接続に失敗する場合に使います。
-ここに設定したホスト名を使って、TLSの検証を通過させることができます。</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLineEdit" name="targetNameOverrideEdit">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
     </layout>
    </item>
    <item>

--- a/ui/Editor.cpp
+++ b/ui/Editor.cpp
@@ -37,14 +37,10 @@ static std::shared_ptr<grpc::ChannelCredentials> getCredentials(
     }
 }
 
-static grpc::ChannelArguments getChannelArguments(Server &server,
-                                                  std::vector<std::shared_ptr<Certificate>> &certificates) {
+static grpc::ChannelArguments getChannelArguments(Server &server) {
     grpc::ChannelArguments args;
-    if (server.useTLS) {
-        auto certificate = server.findCertificate(certificates);
-        if (certificate && !certificate->targetNameOverride.isEmpty()) {
-            args.SetSslTargetNameOverride(certificate->targetNameOverride.toStdString());
-        }
+    if (server.useTLS && !server.tlsTargetNameOverride.isEmpty()) {
+        args.SetSslTargetNameOverride(server.tlsTargetNameOverride.toStdString());
     }
     return args;
 }
@@ -257,7 +253,7 @@ void Editor::onSendButtonClicked() {
 
         auto server = getCurrentServer();
         auto credentials = getCredentials(*server, certificates);
-        auto channelArgs = getChannelArguments(*server, certificates);
+        auto channelArgs = getChannelArguments(*server);
         session = new Session(*method, server->address, credentials, channelArgs, meta.getValues(), this);
         connect(session, &Session::messageSent, this, &Editor::onMessageSent);
         connect(session, &Session::messageReceived, this, &Editor::onMessageReceived);

--- a/ui/ServerEditDialog.h
+++ b/ui/ServerEditDialog.h
@@ -17,6 +17,8 @@ public:
 private slots:
     void onUseTLSCheckChanged(int state);
 
+    void onTargetNameOverrideCheckChanged(int state);
+
     void onOkButtonClick();
 
     void onCancelButtonClick();

--- a/ui/ServerEditDialog.ui
+++ b/ui/ServerEditDialog.ui
@@ -19,23 +19,6 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>接続先名</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLineEdit" name="addressEdit"/>
-     </item>
-     <item row="2" column="1">
-      <widget class="QCheckBox" name="useTLSCheck">
-       <property name="text">
-        <string>&amp;TLSを使用</string>
-       </property>
-      </widget>
-     </item>
      <item row="1" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
@@ -43,8 +26,8 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="1">
-      <widget class="QLineEdit" name="nameEdit"/>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="addressEdit"/>
      </item>
      <item row="3" column="1">
       <widget class="QComboBox" name="certificateComboBox">
@@ -59,6 +42,60 @@
         <string>証明書</string>
        </property>
       </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QCheckBox" name="useTLSCheck">
+       <property name="text">
+        <string>&amp;TLSを使用</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>接続先名</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="nameEdit"/>
+     </item>
+     <item row="4" column="1">
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QCheckBox" name="targetNameOverrideCheck">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>ホスト名検証を別名で偽装</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="targetNameOverrideHelp">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>8</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>接続先アドレスと証明書のCNが異なり、接続に失敗する場合に使います。
+ここに設定したホスト名を使って、TLSの検証を通過させることができます。</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="targetNameOverrideEdit">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
fix #109 

## Screenshot 
![Screenshot_20211008_092314](https://user-images.githubusercontent.com/1352154/136479337-9fb81239-37b5-4c84-ab02-bca90e30b2d4.png)

