### PR TITLE
キャンセルボタンを全ての通信パターンで表示、押下時にgrpc::ClientContext::TryCancelを呼ぶようにした

### DIFF
--- a/entity/Session.cpp
+++ b/entity/Session.cpp
@@ -219,4 +219,9 @@ void Session::finish() {
     call->Finish(&statusBuffer, writeTag());
 }
 
+void Session::cancel() {
+    qDebug() << __FUNCTION__;
+    context.TryCancel();
+}
+
 #include "Session.moc"

--- a/entity/Session.h
+++ b/entity/Session.h
@@ -64,6 +64,8 @@ public slots:
 
     void finish();
 
+    void cancel();
+
 private:
     class SequentialTag {
     public:
@@ -71,7 +73,7 @@ private:
 
         void *operator()() {
             intptr_t tag = reverse ? -count : count;
-            return (void *) tag;
+            return (void *)tag;
         }
 
         void advance() {

--- a/ui/Editor.cpp
+++ b/ui/Editor.cpp
@@ -126,11 +126,6 @@ Editor::Editor(std::unique_ptr<Method> &&method, QWidget *parent)
     } else {
         ui.finishButton->hide();
     }
-    if (this->method->isClientStreaming() || this->method->isServerStreaming()) {
-        ui.cancelButton->show();
-    } else {
-        ui.cancelButton->hide();
-    }
 }
 
 void Editor::setServers(std::vector<std::shared_ptr<Server>> servers) {
@@ -268,6 +263,7 @@ void Editor::onSendButtonClicked() {
     sendingRequest = true;
     updateServerSelectBox();
     updateSendButton();
+    updateCancelButton();
     if (method->isClientStreaming() || method->isServerStreaming()) {
         enableStreamingButtons();
     }
@@ -291,7 +287,7 @@ void Editor::onCancelButtonClicked() {
         return;
     }
 
-    emit session->finish();
+    emit session->cancel();
 
     updateSendButton();
     ui.finishButton->setDisabled(true);
@@ -408,6 +404,7 @@ void Editor::cleanupSession() {
     session = nullptr;
     disableStreamingButtons();
     updateSendButton();
+    updateCancelButton();
     updateServerSelectBox();
 }
 
@@ -472,18 +469,15 @@ void Editor::updateSendButton() {
     ui.sendButton->setDisabled(disabled);
 }
 
-void Editor::enableStreamingButtons() {
-    ui.cancelButton->setDisabled(false);
+void Editor::updateCancelButton() { ui.cancelButton->setDisabled(session == nullptr); }
 
+void Editor::enableStreamingButtons() {
     if (method->isClientStreaming()) {
         ui.finishButton->setDisabled(false);
     }
 }
 
-void Editor::disableStreamingButtons() {
-    ui.finishButton->setDisabled(true);
-    ui.cancelButton->setDisabled(true);
-}
+void Editor::disableStreamingButtons() { ui.finishButton->setDisabled(true); }
 
 void Editor::updateResponsePager() {
     ui.responseBodyPager->setDisabled(false);

--- a/ui/Editor.h
+++ b/ui/Editor.h
@@ -91,6 +91,8 @@ private:
 
     void updateSendButton();
 
+    void updateCancelButton();
+
     void enableStreamingButtons();
 
     void disableStreamingButtons();


### PR DESCRIPTION
fix #102 

キャンセルボタンを押した時はFinish()を実行していたが、TryCancel()を呼び出すように変更した。通信の正常終了であればFinish()を使うが、キャンセルの場合はTryCancel()を呼び出して中断を試みないと通信待ちのままになってしまう。

また、キャンセルはストリーミングを使用しない場合にも有用なので、常にキャンセルボタンを表示するようにした。